### PR TITLE
Milestone Bonus: admin portal SSO behind a runtime flag

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -56,6 +56,10 @@ FORWARD_MAILHOG_DASHBOARD_PORT=18025
 WEBSITE_PORT=8091
 MYCURRICULUM_URL=http://localhost:8091/MyCurriculum.php
 
+# Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
+# No port: the admin session cookie only survives on http://localhost/admin.
+ADMIN_PORTAL_URL=http://localhost/admin
+
 WWWUSER=1000
 WWWGROUP=1000
 

--- a/.env.dev
+++ b/.env.dev
@@ -83,6 +83,7 @@ CREATEACCOUNT_URL=http://localhost:8091/CreateAccountLanding.php
 # SAML SP configuration
 SAML_SP_ENTITY_ID=http://localhost:8090/saml/metadata
 MOCK_IDP_PORT=8092
+MOCK_IDP_ADMIN_PORT=8093
 
 # Dusk browser tests: selenium runs with network_mode: host, so its Chrome
 # reaches the apps at http://localhost:809x; the login container reaches

--- a/.env.example
+++ b/.env.example
@@ -53,4 +53,7 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
 
+# Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
+ADMIN_PORTAL_URL=
+
 ADMIN_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
 
 # Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
-ADMIN_PORTAL_URL=
+# Defaults to the production portal when unset.
+# ADMIN_PORTAL_URL=
 
 ADMIN_API_TOKEN=

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ db:
 		&& php artisan saml:client update local-idp --metadata=/tmp/mock-idp-metadata.xml \
 		&& php artisan saml:client enable local-idp" \
 		|| echo "mock-idp not reachable; SAML client left disabled (run 'docker compose up -d mock-idp' then 'make db')"
+	$(EXEC) sh -c "curl -sf -H 'Host: localhost:$${MOCK_IDP_ADMIN_PORT:-8093}' http://mock-idp-admin:8080/simplesaml/saml2/idp/metadata.php -o /tmp/mock-idp-admin-metadata.xml \
+		&& php artisan saml:client update local-admin-idp --metadata=/tmp/mock-idp-admin-metadata.xml \
+		&& php artisan saml:client enable local-admin-idp" \
+		|| echo "mock-idp-admin not reachable; admin SSO client left disabled (run 'docker compose up -d mock-idp-admin' then 'make db')"
 
 users:
 	$(EXEC) php artisan local:users

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -28,6 +28,8 @@ class SamlClientCommand extends Command
         {--no-jit : disable just-in-time provisioning}
         {--metadata= : path to an IdP metadata XML file}
         {--domains= : comma-separated email domains for SP-initiated SSO routing (replaces the list)}
+        {--admin-portal : mark the client as asserting admin-portal (Employee) identities}
+        {--no-admin-portal : clear the admin-portal marker}
         {--wizard : create a client interactively (create action only)}';
 
     protected $description = 'Manage SAML SSO client configurations';
@@ -76,6 +78,7 @@ class SamlClientCommand extends Command
                 $client->name,
                 $client->enabled ? 'yes' : 'no',
                 $client->jit_enabled ? 'yes' : 'no',
+                $client->admin_portal ? 'yes' : '',
                 $client->organization_id,
                 $client->department_id ?? '-',
                 implode(', ', $client->email_domains ?? []),
@@ -84,7 +87,7 @@ class SamlClientCommand extends Command
             ];
         });
 
-        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Org', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
+        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Admin', 'Org', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
 
         return self::SUCCESS;
     }
@@ -98,6 +101,7 @@ class SamlClientCommand extends Command
         $this->line("Slug: {$client->slug}");
         $this->line('Enabled: '.($client->enabled ? 'yes' : 'no'));
         $this->line('JIT provisioning: '.($client->jit_enabled ? 'yes' : 'no'));
+        $this->line('Admin portal: '.($client->admin_portal ? 'yes' : 'no'));
         $this->line("Organization ID: {$client->organization_id}");
         $this->line('Department ID: '.($client->department_id ?? 'none (users select their department at finish-account)'));
         $this->line('Email domains: '.(implode(', ', $client->email_domains ?? []) ?: 'none (IdP-initiated only)'));
@@ -126,6 +130,10 @@ class SamlClientCommand extends Command
 
         if (! $this->option('wizard') && ($domains = $this->domainsOption()) !== null) {
             $input['email_domains'] = $domains;
+        }
+
+        if (! $this->option('wizard') && $this->option('admin-portal')) {
+            $input['admin_portal'] = true;
         }
 
         $client = $manager->create($input);
@@ -266,6 +274,12 @@ class SamlClientCommand extends Command
         }
         if ($this->option('no-jit')) {
             $client = $manager->update($client, ['jit_enabled' => false]);
+        }
+        if ($this->option('admin-portal')) {
+            $client = $manager->update($client, ['admin_portal' => true]);
+        }
+        if ($this->option('no-admin-portal')) {
+            $client = $manager->update($client, ['admin_portal' => false]);
         }
 
         return $client;

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 class SamlClientController extends Controller
 {
     /** Field names the manager's validators accept — the audit trail logs only these. */
-    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'email_domains', 'attribute_map'];
+    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
 
     public function __construct(private SamlClientManager $manager) {}
 
@@ -128,6 +128,7 @@ class SamlClientController extends Controller
             'slug' => $client->slug,
             'enabled' => $client->enabled,
             'jit_enabled' => $client->jit_enabled,
+            'admin_portal' => $client->admin_portal,
             'organization_id' => $client->organization_id,
             'department_id' => $client->department_id,
             'email_domains' => $client->email_domains ?? [],

--- a/app/Http/Controllers/Api/Admin/SsoHandoffController.php
+++ b/app/Http/Controllers/Api/Admin/SsoHandoffController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SsoHandoffController extends Controller
+{
+    /**
+     * Exchange a single-use admin SSO token for the Employee identity.
+     * Called server-to-server by website_admin/ssoLogon.php; the token
+     * arriving in a browser URL is worthless without the bearer token.
+     */
+    public function redeem(Request $request, AdminSsoHandoff $handoff): JsonResponse
+    {
+        $payload = $handoff->redeem((string) $request->input('token', ''));
+
+        abort_if($payload === null, 404);
+
+        return response()->json(['data' => $payload]);
+    }
+}

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\SamlClient;
 use App\Models\User;
+use App\Saml\AdminSsoHandoff;
 use App\Saml\SamlClientManager;
 use App\Saml\SamlLoginRejected;
 use App\Saml\SamlSettingsFactory;
@@ -21,6 +22,7 @@ class SamlController extends Controller
     public function __construct(
         private SamlSettingsFactory $settings,
         private SamlUserProvisioner $provisioner,
+        private AdminSsoHandoff $adminHandoff,
     ) {}
 
     public function acs(Request $request, string $slug)
@@ -63,6 +65,19 @@ class SamlController extends Controller
 
         if ($email === null) {
             return $this->reject($client, ['reason' => 'no_email_attribute']);
+        }
+
+        // Admin-portal clients assert Employee identities: no JIT, no Users
+        // lookup, no Laravel session — hand off to the portal's own session
+        // world via a single-use token (spec: admin portal SSO).
+        if ($client->admin_portal) {
+            try {
+                $redirect = $this->adminHandoff->initiate($client, $email);
+            } catch (SamlLoginRejected $e) {
+                return $this->reject($client, $e->logContext, $e->publicMessage);
+            }
+
+            return redirect()->away($redirect);
         }
 
         try {

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -67,6 +67,15 @@ class SamlController extends Controller
             return $this->reject($client, ['reason' => 'no_email_attribute']);
         }
 
+        // Spec: warn while assertions still validate but the IdP cert nears expiry
+        $certStatus = app(SamlClientManager::class)->certificateStatus($client);
+        if ($certStatus['expiring']) {
+            Log::warning('SAML client IdP certificate expires soon', [
+                'client' => $client->slug,
+                'expires_at' => $certStatus['expires_at']?->toDateString(),
+            ]);
+        }
+
         // Admin-portal clients assert Employee identities: no JIT, no Users
         // lookup, no Laravel session — hand off to the portal's own session
         // world via a single-use token (spec: admin portal SSO).
@@ -84,15 +93,6 @@ class SamlController extends Controller
             $user = $this->provisioner->provision($client, $email, $firstName, $lastName);
         } catch (SamlLoginRejected $e) {
             return $this->reject($client, $e->logContext, $e->publicMessage);
-        }
-
-        // Spec: warn while assertions still validate but the IdP cert nears expiry
-        $certStatus = app(SamlClientManager::class)->certificateStatus($client);
-        if ($certStatus['expiring']) {
-            Log::warning('SAML client IdP certificate expires soon', [
-                'client' => $client->slug,
-                'expires_at' => $certStatus['expires_at']?->toDateString(),
-            ]);
         }
 
         $this->establishSession($request, $user, $client);

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+/**
+ * Apex staff — the admin portal's auth table (website_admin/doLogon.php).
+ * Read-only from this app's perspective: SSO matches rows, never writes them.
+ */
+class Employee extends LegacyModel
+{
+    protected $table = 'Employees';
+
+    public $timestamps = false;
+}

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -19,6 +19,7 @@ class SamlClient extends Model
         'organization_id',
         'department_id',
         'jit_enabled',
+        'admin_portal',
         'attribute_map',
         'email_domains',
     ];
@@ -26,6 +27,7 @@ class SamlClient extends Model
     protected $casts = [
         'enabled' => 'boolean',
         'jit_enabled' => 'boolean',
+        'admin_portal' => 'boolean',
         'attribute_map' => 'array',
         'email_domains' => 'array',
     ];
@@ -47,6 +49,7 @@ class SamlClient extends Model
     public static function forEmailDomain(string $domain): ?self
     {
         return static::where('enabled', true)
+            ->where('admin_portal', false)
             ->whereJsonContains('email_domains', strtolower($domain))
             ->first();
     }

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -37,7 +37,7 @@ class AdminSsoHandoff
             (int) config('saml.admin_handoff_ttl'),
         );
 
-        Log::info('SAML admin portal login', [
+        Log::info('Admin portal SSO handoff initiated', [
             'client' => $client->slug,
             'employee_id' => $employee->ID,
         ]);
@@ -56,9 +56,17 @@ class AdminSsoHandoff
         $store = Cache::store(config('saml.replay_store'));
 
         if (! $store->add(self::KEY_PREFIX.'claim:'.$token, 1, (int) config('saml.admin_handoff_ttl'))) {
+            Log::warning('Admin SSO handoff redemption failed', ['already_claimed' => true]);
+
             return null;
         }
 
-        return $store->pull(self::KEY_PREFIX.$token);
+        $payload = $store->pull(self::KEY_PREFIX.$token);
+
+        if ($payload === null) {
+            Log::warning('Admin SSO handoff redemption failed', ['already_claimed' => false]);
+        }
+
+        return $payload;
     }
 }

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -46,10 +46,19 @@ class AdminSsoHandoff
     }
 
     /**
-     * Single-use: pull deletes atomically, so a second redemption is null.
+     * Single-use: Cache::pull() alone is get-then-forget (not atomic on
+     * redis), so claim the token with an atomic add() first — the same
+     * discipline as the SAML assertion replay guard — making concurrent
+     * redemptions of one token impossible.
      */
     public function redeem(string $token): ?array
     {
-        return Cache::store(config('saml.replay_store'))->pull(self::KEY_PREFIX.$token);
+        $store = Cache::store(config('saml.replay_store'));
+
+        if (! $store->add(self::KEY_PREFIX.'claim:'.$token, 1, (int) config('saml.admin_handoff_ttl'))) {
+            return null;
+        }
+
+        return $store->pull(self::KEY_PREFIX.$token);
     }
 }

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Saml;
+
+use App\Models\Employee;
+use App\Models\SamlClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Bridges a validated admin-portal SAML assertion into the legacy portal's
+ * own session world: match an active Employee (fail closed, never JIT),
+ * mint a short-lived single-use token, and send the browser to the portal's
+ * ssoLogon.php, which redeems the token server-side through the admin API.
+ */
+class AdminSsoHandoff
+{
+    private const KEY_PREFIX = 'admin_sso:token:';
+
+    public function initiate(SamlClient $client, string $email): string
+    {
+        $employee = Employee::where('Email', $email)->where('Active', 'Y')->first();
+
+        if (! $employee) {
+            throw new SamlLoginRejected(
+                'Your account is not authorized for the admin portal. Contact your administrator.',
+                ['reason' => 'no_employee_match', 'email' => $email],
+            );
+        }
+
+        $token = Str::random(64);
+
+        Cache::store(config('saml.replay_store'))->put(
+            self::KEY_PREFIX.$token,
+            ['employee_id' => $employee->ID, 'name' => $employee->FirstName.' '.$employee->LastName],
+            (int) config('saml.admin_handoff_ttl'),
+        );
+
+        Log::info('SAML admin portal login', [
+            'client' => $client->slug,
+            'employee_id' => $employee->ID,
+        ]);
+
+        return rtrim(config('saml.admin_portal_url'), '/').'/ssoLogon.php?token='.$token;
+    }
+
+    /**
+     * Single-use: pull deletes atomically, so a second redemption is null.
+     */
+    public function redeem(string $token): ?array
+    {
+        return Cache::store(config('saml.replay_store'))->pull(self::KEY_PREFIX.$token);
+    }
+}

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -61,6 +61,7 @@ class SamlClientManager
             'organization_id' => ['required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
+            'admin_portal' => ['sometimes', 'boolean'],
             'attribute_map' => ['sometimes', 'array'],
             'attribute_map.email' => ['required_with:attribute_map', 'string'],
             'attribute_map.first_name' => ['sometimes', 'string'],
@@ -70,6 +71,11 @@ class SamlClientManager
         ])->validate();
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], null);
+
+        $this->assertAdminPortalHoldsNoDomains(
+            (bool) ($validated['admin_portal'] ?? false),
+            $validated['email_domains'] ?? [],
+        );
 
         return SamlClient::create($validated + [
             'enabled' => false, // enabled explicitly once IdP metadata is in place
@@ -94,6 +100,7 @@ class SamlClientManager
             'organization_id' => ['sometimes', 'required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
+            'admin_portal' => ['sometimes', 'boolean'],
             'attribute_map' => ['sometimes', 'array'],
             'attribute_map.email' => ['required_with:attribute_map', 'string'],
             'attribute_map.first_name' => ['sometimes', 'string'],
@@ -103,6 +110,11 @@ class SamlClientManager
         ])->validate();
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $client);
+
+        $this->assertAdminPortalHoldsNoDomains(
+            (bool) ($validated['admin_portal'] ?? $client->admin_portal),
+            $validated['email_domains'] ?? ($client->email_domains ?? []),
+        );
 
         $client->update($validated);
 
@@ -171,6 +183,19 @@ class SamlClientManager
                     'email_domains' => "Domain {$domain} is already claimed by another SAML client.",
                 ]);
             }
+        }
+    }
+
+    /**
+     * Admin-portal clients assert Employee identities and never participate
+     * in customer email-domain routing (spec: admin portal SSO).
+     */
+    private function assertAdminPortalHoldsNoDomains(bool $adminPortal, array $domains): void
+    {
+        if ($adminPortal && $domains !== []) {
+            throw ValidationException::withMessages([
+                'email_domains' => 'An admin-portal client cannot claim email domains.',
+            ]);
         }
     }
 }

--- a/config/saml.php
+++ b/config/saml.php
@@ -13,4 +13,8 @@ return [
     // Cache store + TTL for assertion-ID replay protection
     'replay_store' => env('SAML_REPLAY_STORE', 'redis'),
     'replay_ttl' => env('SAML_REPLAY_TTL', 300),
+
+    // Admin portal SSO handoff (docs/specs/2026-07-09-admin-portal-sso.md)
+    'admin_portal_url' => env('ADMIN_PORTAL_URL', 'https://www.apexinnovations.com/admin'),
+    'admin_handoff_ttl' => env('ADMIN_HANDOFF_TTL', 60),
 ];

--- a/database/factories/SamlClientFactory.php
+++ b/database/factories/SamlClientFactory.php
@@ -24,6 +24,7 @@ class SamlClientFactory extends Factory
             'organization_id' => 1,
             'department_id' => null,
             'jit_enabled' => true,
+            'admin_portal' => false,
             'attribute_map' => [
                 'email' => 'email',
                 'first_name' => 'firstName',
@@ -31,5 +32,11 @@ class SamlClientFactory extends Factory
             ],
             'email_domains' => [],
         ];
+    }
+
+    /** A client asserting Employee (admin portal) identities. */
+    public function adminPortal(): static
+    {
+        return $this->state(fn () => ['admin_portal' => true]);
     }
 }

--- a/database/migrations/2026_07_09_100000_add_admin_portal_to_saml_clients_table.php
+++ b/database/migrations/2026_07_09_100000_add_admin_portal_to_saml_clients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('saml_clients', function (Blueprint $table) {
+            // Marks a client that asserts Employee (admin portal) identities
+            // rather than Users; see docs/specs/2026-07-09-admin-portal-sso.md
+            $table->boolean('admin_portal')->default(false)->after('jit_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->dropColumn('admin_portal');
+        });
+    }
+};

--- a/database/seeders/LocalEmployeeSeeder.php
+++ b/database/seeders/LocalEmployeeSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class LocalEmployeeSeeder extends Seeder
 {
@@ -28,6 +29,19 @@ class LocalEmployeeSeeder extends Seeder
                 'FirstName' => 'Dev',
                 'LastName' => 'Admin',
                 'Password' => md5('p6^8&password'),
+                'Active' => 'Y',
+                'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+            ],
+        );
+
+        // The mock IdP's static user1 assertion (email user1@example.com),
+        // seeded as an active Employee so admin-portal SSO can match it.
+        DB::table('Employees')->updateOrInsert(
+            ['Email' => 'user1@example.com'],
+            [
+                'FirstName' => 'Mock',
+                'LastName' => 'IdPAdmin',
+                'Password' => md5('p6^8&'.Str::random(32)), // never used; SSO only
                 'Active' => 'Y',
                 'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
             ],

--- a/database/seeders/LocalSamlClientSeeder.php
+++ b/database/seeders/LocalSamlClientSeeder.php
@@ -34,5 +34,23 @@ class LocalSamlClientSeeder extends Seeder
             ],
             'email_domains' => ['example.com'],
         ]);
+
+        // Local mock IdP for the *admin portal* SSO flow (second container,
+        // mock-idp-admin, because the image only supports one SP ACS URL).
+        // user1@example.com is seeded as an Employee by LocalEmployeeSeeder.
+        SamlClient::updateOrCreate(['slug' => 'local-admin-idp'], [
+            'name' => 'Local Mock IdP (Admin Portal)',
+            'enabled' => false,
+            'admin_portal' => true,
+            'idp_entity_id' => 'pending',
+            'idp_sso_url' => 'pending',
+            'idp_certificate' => 'pending',
+            'organization_id' => 933,
+            'department_id' => null,
+            'jit_enabled' => false,
+            'attribute_map' => [
+                'email' => 'email',
+            ],
+        ]);
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,16 @@ services:
             SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: 'http://localhost:8090/saml/local-idp/acs'
         networks:
             - sail
+    mock-idp-admin:
+        image: 'kristophjunge/test-saml-idp'
+        ports:
+            - '${MOCK_IDP_ADMIN_PORT:-8093}:8080'
+        environment:
+            SIMPLESAMLPHP_SP_ENTITY_ID: '${APP_URL:-http://localhost:8090}/saml/metadata'
+            SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: 'http://localhost:8090/saml/local-admin-idp/acs'
+            SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: 'http://localhost:8090/saml/local-admin-idp/acs'
+        networks:
+            - sail
     mysql:
         image: 'mysql:8.0'
         # Legacy production MySQL runs non-strict (no ONLY_FULL_GROUP_BY / STRICT_TRANS_TABLES)

--- a/docker/website.env.dev
+++ b/docker/website.env.dev
@@ -39,3 +39,6 @@ LOGIN_URL=http://localhost:8090
 # must match ADMIN_API_TOKEN in login/.env.dev.
 LOGIN_API_URL=http://login
 LOGIN_ADMIN_API_TOKEN=local-dev-admin-token
+
+# Slug of the admin-portal SAML client on the login app (apex-admin in prod).
+LOGIN_SSO_CLIENT=local-admin-idp

--- a/docs/specs/2026-07-09-admin-portal-sso.md
+++ b/docs/specs/2026-07-09-admin-portal-sso.md
@@ -1,0 +1,126 @@
+# Admin Portal SSO — Design
+
+Bonus effort beyond the fixed-bid milestones: put the legacy admin portal
+(`website_admin`) itself behind SAML SSO, so Apex employees sign into it through the
+company IdP instead of (or alongside) the portal's static-salted-MD5 password check
+(`doLogon.php`). Feature-flagged so it can be switched on and off at runtime without a
+deploy.
+
+Two codebases again: the SAML/identity side in this repo, a small callback script and
+login button in `website_admin` (sibling checkout).
+
+## The flag
+
+A new boolean column `admin_portal` on `saml_clients` (default false; settable via
+`saml:client create/update --admin-portal`, surfaced in the admin API and portal page).
+One client row — slug `apex-admin`, pointed at the internal IdP — carries it.
+
+The client's existing `enabled` state **is** the feature flag. `saml:client disable
+apex-admin` (or the portal page's disable button) switches admin SSO off at runtime;
+the SP-login and ACS endpoints already 404 disabled clients server-side, and the
+portal's SSO button hides itself (below). No env vars, no deploy, one source of truth.
+
+An `admin_portal` client is excluded from `/sso/lookup` email-domain routing and the
+domain-claim machinery entirely — it never participates in customer SP-initiated flows.
+
+Password login (`doLogon.php`) stays fully functional regardless of the flag. SSO is
+additive; if the IdP or the login app is down, admins still get in. Retiring the MD5
+path is a separate, later decision.
+
+## Trust model
+
+Portal admins are `Employees` rows (keyed by corporate `Email`, `Active = 'Y'`).
+Membership in that table is the authorization — the ACS matches the asserted email
+against `Employees` and **fails closed**: no row, or an inactive row, means the
+standard rejection page with a logged `reason` (`no_employee_match`). There is no JIT
+provisioning and no fallback to the `Users` table on an `admin_portal` client, and no
+`Auth::login()` either — a Laravel session in the login app means nothing to the
+portal. Existing per-page `Level`/`SalesRep` checks keep working untouched, since they
+read the same Employees row.
+
+The handoff into the portal's own session realm reuses the milestone-4 service-token
+bridge rather than teaching the login app to forge `ApexAdmin` sessions:
+
+- **One-time token.** After a successful match the ACS stores
+  `{employee_id, name}` in the cache under `admin_sso:token:{64-char random}`,
+  TTL 60 seconds, and 302s the browser to `{portal_url}/ssoLogon.php?token=...`.
+- **Server-side redemption.** `POST /api/admin/sso-handoff/redeem` (behind
+  `admin.api`, same `ADMIN_API_TOKEN`) atomically deletes-and-returns the payload;
+  a second redemption of the same token fails. Possession of the redirect URL alone
+  is useless without the portal's server-side API credential.
+
+Rejected alternatives: the login app writing the `ApexAdmin` Redis session directly
+(couples it to the portal session handler's ID-encryption and serialization internals —
+mousetrap-y, kept as a fallback if the callback approach hits deploy friction);
+portal-side php-saml (duplicates the whole milestone-2 stack in legacy PHP with no test
+harness).
+
+## ACS branch (this repo)
+
+`SamlController::acs` gains one branch: when `$client->admin_portal`, skip the
+`SamlUserProvisioner` / session establishment entirely and call an
+`AdminSsoHandoff` service — look up the Employee, mint the token, redirect. Everything
+before the branch (signature validation, replay guard, cert-expiry warning, identity
+extraction via the client's `attribute_map`) is shared with the normal flow unchanged.
+The success log line records `employee_id` rather than `user_id`.
+
+New config: `saml.admin_portal_url` (env `ADMIN_PORTAL_URL`) — the base the ACS
+redirects to. Local: the website container's admin path; prod:
+`https://www.apexinnovations.com/admin`.
+
+## Portal side (`website_admin`)
+
+New `ssoLogon.php`, mirroring `doLogon.php`'s contract:
+
+1. `require SESSIONCONFIG.php` — native `ApexAdmin` session, nothing custom.
+2. Redeem `$_GET['token']` server-to-server via the same curl/env pattern as
+   `doSSOClients.php`'s `loginApi()` helper.
+3. On success: `session_regenerate_id(true)` (fixation), set `$_SESSION['AdminID']`
+   and `$_SESSION['AdminName']`, set `$_SESSION['SSOLogin'] = true`, insert the
+   `AdminEvents` type-1 (login) row via `apx_AdminEvent` — insert failure is access
+   denied, exactly like `doLogon.php` — then redirect to `Home.php`.
+4. Any failure: redirect to `Home.php?error=Access Denied`, same as password failures.
+
+`HEADER.php` changes:
+
+- A "Sign in with SSO" button beside the existing login form, linking to the login
+  app's `/saml/apex-admin/login`. Shown only when the flag is on: a small server-side
+  check through the API bridge (`GET /api/admin/saml-clients/apex-admin`, result cached
+  in the session for 60 seconds) — if the check errors or the client is missing or
+  disabled, the button hides and nothing else is affected.
+- The 90-day `PasswordLastChanged` forced-reset redirect is skipped when
+  `$_SESSION['SSOLogin']` is set — password age is meaningless in an SSO session.
+
+## Testing
+
+Login app (phpunit, MySQL):
+
+- `admin_portal` flag: migration, CLI `--admin-portal`, API create/update/detail.
+- ACS matcher: active Employee matches; inactive and unknown emails rejected with
+  `no_employee_match`; a non-admin client's flow is completely unaffected; no `Users`
+  row is created or touched.
+- Handoff: token minted with TTL and correct payload; redeem returns it exactly once
+  (second call 404s); expired token 404s; redeem requires the admin token.
+- `/sso/lookup` never routes to an `admin_portal` client.
+
+End-to-end (Dusk + mock IdP + website container):
+
+- Seed a second mock client `local-admin-idp` with `admin_portal = true` (the mock
+  IdP's static `user1` email seeded as an active Employee, alongside `dev.admin`).
+  The `kristophjunge/test-saml-idp` image is configured for a single SP ACS URL, so
+  this likely means a second container instance (`mock-idp-admin`) in
+  `docker-compose.yml` pointing at `/saml/local-admin-idp/acs` — cheap, and keeps the
+  customer-flow mock untouched.
+- Flag on: click the SSO button on the portal login form → mock IdP → land on
+  `Home.php` with the admin menu rendered; `AdminEvents` has the type-1 row.
+- Flag off (`saml:client disable local-admin-idp`): button absent, `/saml/local-admin-idp/login` 404s.
+
+## Rollout
+
+1. Deploy the login app (inert: no `admin_portal` client exists; migration adds the
+   column automatically via the `migrations_login` startup migrate).
+2. Deploy `website_admin` (inert: flag off, button hidden, `ssoLogon.php` unreachable
+   without a token).
+3. `saml:client create` the `apex-admin` client against the internal IdP metadata,
+   `--admin-portal`, verify with a test employee, `enable` when satisfied.
+4. Switch off any time: `saml:client disable apex-admin` or the portal toggle.

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -238,6 +238,7 @@ table to translate a logged reason into a cause and fix.
 | `no_email_attribute`          | The assertion did not carry an email in the attribute named by the client's attribute map, and no usable NameID was present either. | Fix the customer's attribute mapping (Okta attribute statements or Entra claim names) so the app's mapped `email` field is actually sent; verify with `saml:client list`/`update` that the attribute map matches what the IdP sends. |
 | `disabled_user`               | The matched Apex user has `Disabled='Y'`.                                                       | Reactivate the account in the admin site if the user should regain access.                              |
 | `unknown_user_jit_disabled`   | No existing Apex user matches the login, and JIT provisioning is off for this client.            | Either enable JIT (`saml:client update <slug> --jit`) or pre-create the user account manually before the customer's users start logging in. |
+| `no_employee_match`           | SAML login on an admin-portal client asserted an email with no active Employees row.             | Verify the employee's Email and Active='Y' in the Employees table; admin SSO never auto-creates accounts. |
 
 ## Validation checklist (run once against the Okta integrator account)
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -202,6 +202,30 @@ belongs to other applications and is never read or written. No manual
 migration step is needed; a failed migration stops the new container before
 it serves, leaving the previous deployment running.
 
+## Admin portal SSO (apex-admin)
+
+The admin portal itself can sit behind SSO. A SAML client marked
+`--admin-portal` asserts *Employee* identities (the portal's own auth table):
+the ACS matches `Employees.Email` (active rows only, never JIT-provisions),
+mints a 60-second single-use token, and redirects to the portal's
+`ssoLogon.php`, which redeems it server-to-server (`POST
+/api/admin/sso-handoff/redeem`, same `ADMIN_API_TOKEN` bridge as the SSO
+Clients page) and establishes the normal portal session. Password login is
+unaffected; both paths coexist.
+
+**The feature flag is the client's `enabled` state.** `saml:client disable
+apex-admin` (or the portal toggle) turns admin SSO off at runtime: the
+login/ACS endpoints 404 and the portal's "Sign in with SSO" button hides
+itself within a minute. Admin-portal clients cannot claim email domains and
+never appear in `/sso/lookup` routing.
+
+Rollout: deploy login app, deploy website_admin, then
+`saml:client create --name="Apex Admin" --org=<org> --admin-portal`,
+apply the internal IdP's metadata, verify with a test employee, and
+`saml:client enable apex-admin`. Set `LOGIN_SSO_CLIENT=apex-admin` in the
+portal's env. Local dev uses the second mock IdP (`mock-idp-admin`,
+client `local-admin-idp`, login user1/user1pass).
+
 ## Troubleshooting
 
 The application logs a `reason` value on every rejected SAML login. Use this

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\Admin\LookupController;
 use App\Http\Controllers\Api\Admin\SamlClientController;
 use App\Http\Controllers\Api\Admin\SsoGrantController;
+use App\Http\Controllers\Api\Admin\SsoHandoffController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -34,4 +35,5 @@ Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function 
     Route::post('/saml-clients/{slug}/disable', [SamlClientController::class, 'disable'])->name('saml-clients.disable');
     Route::get('/saml-clients/{slug}/grants', [SsoGrantController::class, 'index'])->name('saml-clients.grants.index');
     Route::put('/saml-clients/{slug}/grants', [SsoGrantController::class, 'replace'])->name('saml-clients.grants.replace');
+    Route::post('/sso-handoff/redeem', [SsoHandoffController::class, 'redeem'])->name('sso-handoff.redeem');
 });

--- a/tests/Browser/AdminPortalSsoTest.php
+++ b/tests/Browser/AdminPortalSsoTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\SamlClient;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+/**
+ * Full admin-portal SSO round trip against mock-idp-admin. Requires
+ * `make db` state with the mock-idp-admin container up (local-admin-idp
+ * enabled) — same convention as the other Browser suites.
+ */
+class AdminPortalSsoTest extends DuskTestCase
+{
+    private function adminUrl(): string
+    {
+        return env('DUSK_ADMIN_URL', 'http://localhost/admin');
+    }
+
+    private function setClientEnabled(bool $enabled): void
+    {
+        SamlClient::where('slug', 'local-admin-idp')->update(['enabled' => $enabled]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setClientEnabled(true); // leave make-db state behind for reruns
+
+        parent::tearDown();
+    }
+
+    public function test_sso_button_logs_admin_in_through_mock_idp(): void
+    {
+        $this->setClientEnabled(true);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->adminUrl().'/doLogoff.php') // fresh session
+                ->visit($this->adminUrl().'/Home.php')
+                ->waitForText('Sign in with SSO', 10)
+                ->clickLink('Sign in with SSO')
+                // kristophjunge simplesamlphp login form
+                ->waitFor('#username', 10)
+                ->type('#username', 'user1')
+                ->type('#password', 'user1pass')
+                ->press('Login')
+                // Home.php renders #adminID only with $_SESSION['AdminID'] set
+                ->waitFor('#adminID', 15)
+                ->assertSee('Mock IdPAdmin');
+        });
+    }
+
+    public function test_disabled_flag_hides_button_and_404s_login(): void
+    {
+        $this->setClientEnabled(false);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->adminUrl().'/doLogoff.php') // fresh session: SSOAvailable cache lives in it
+                ->visit($this->adminUrl().'/Home.php')
+                ->waitFor('#Logon', 10)
+                ->assertDontSee('Sign in with SSO');
+
+            $browser->visit(rtrim(env('APP_URL', 'http://localhost:8090'), '/').'/saml/local-admin-idp/login')
+                ->assertSee('404');
+        });
+    }
+}

--- a/tests/Feature/AdminApiSsoHandoffTest.php
+++ b/tests/Feature/AdminApiSsoHandoffTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdminApiSsoHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // Alphabetically the first RefreshDatabase class in the suite, so it
+    // decides whether the one-time migrate:fresh seeds. $seed = true keeps
+    // the suite-wide seed pass alive (see ReferenceDataSeederTest's note).
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['admin.api_token' => 'test-token', 'saml.replay_store' => 'array',
+            'saml.admin_portal_url' => 'http://localhost/admin']);
+    }
+
+    private function authHeaders(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+    }
+
+    private function mintToken(): string
+    {
+        DB::table('Employees')->insert([
+            'Email' => 'jane@apexinnovations.com', 'FirstName' => 'Jane', 'LastName' => 'Doe',
+            'Password' => md5('p6^8&x'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+
+        $client = SamlClient::factory()->adminPortal()->create();
+        $url = app(AdminSsoHandoff::class)->initiate($client, 'jane@apexinnovations.com');
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+        return $query['token'];
+    }
+
+    public function test_token_redeems_exactly_once(): void
+    {
+        $token = $this->mintToken();
+
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => $token], $this->authHeaders())
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Jane Doe');
+
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => $token], $this->authHeaders())
+            ->assertNotFound();
+    }
+
+    public function test_unknown_token_404s(): void
+    {
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => 'nope'], $this->authHeaders())
+            ->assertNotFound();
+    }
+
+    public function test_requires_admin_token(): void
+    {
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => 'anything'])
+            ->assertUnauthorized();
+    }
+}

--- a/tests/Feature/AdminPortalSamlLoginTest.php
+++ b/tests/Feature/AdminPortalSamlLoginTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\SamlResponseFactory;
+use Tests\TestCase;
+
+class AdminPortalSamlLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'saml.sp.cert_path' => base_path('tests/Fixtures/saml/sp.crt'),
+            'saml.sp.key_path' => base_path('tests/Fixtures/saml/sp.key'),
+            'saml.replay_store' => 'array',
+            'saml.admin_portal_url' => 'http://localhost/admin',
+        ]);
+
+        SamlClient::factory()->adminPortal()->create([
+            'slug' => 'apex-admin',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'organization_id' => 933,
+            'jit_enabled' => false,
+        ]);
+
+        DB::table('Employees')->insert([
+            'Email' => 'sso.user@acme.test', 'FirstName' => 'Sso', 'LastName' => 'User',
+            'Password' => md5('p6^8&irrelevant'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    private function acs(array $responseOverrides = []): TestResponse
+    {
+        return $this->post('/saml/apex-admin/acs', [
+            'SAMLResponse' => SamlResponseFactory::make(
+                ['destination' => url('/saml/apex-admin/acs')] + $responseOverrides
+            ),
+        ]);
+    }
+
+    public function test_active_employee_is_redirected_to_portal_with_token(): void
+    {
+        $response = $this->acs();
+
+        $response->assertStatus(302);
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith('http://localhost/admin/ssoLogon.php?token=', $location);
+
+        parse_str(parse_url($location, PHP_URL_QUERY), $query);
+        $payload = app(AdminSsoHandoff::class)->redeem($query['token']);
+        $this->assertSame('Sso User', $payload['name']);
+    }
+
+    public function test_no_laravel_session_and_no_user_row(): void
+    {
+        $this->acs();
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('Users', ['Login' => 'sso.user@acme.test']);
+    }
+
+    public function test_unknown_email_gets_rejection_page(): void
+    {
+        $response = $this->acs(['nameId' => 'ghost@acme.test', 'attributes' => [
+            'email' => 'ghost@acme.test', 'firstName' => 'Gho', 'lastName' => 'St',
+        ]]);
+
+        $response->assertStatus(403);
+        $this->assertGuest();
+    }
+
+    public function test_inactive_employee_gets_rejection_page(): void
+    {
+        DB::table('Employees')->where('Email', 'sso.user@acme.test')->update(['Active' => 'N']);
+
+        $this->acs()->assertStatus(403);
+    }
+}

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -51,4 +51,13 @@ class AdminSamlClientReadTest extends TestCase
     {
         $this->getJson('/api/admin/saml-clients/nope', $this->headers())->assertNotFound();
     }
+
+    public function test_detail_includes_admin_portal_flag(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->getJson('/api/admin/saml-clients/apex-admin', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.admin_portal', true);
+    }
 }

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -105,4 +105,13 @@ class AdminSamlClientWriteTest extends TestCase
                    ! array_key_exists('email_domains', $context);
         })->once();
     }
+
+    public function test_api_rejects_domains_on_admin_portal_client(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->patchJson('/api/admin/saml-clients/apex-admin', ['email_domains' => ['apexinnovations.com']], $this->headers())
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('email_domains');
+    }
 }

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -6,6 +6,7 @@ use App\Models\SamlClient;
 use App\Saml\AdminSsoHandoff;
 use App\Saml\SamlLoginRejected;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -72,5 +73,18 @@ class AdminSsoHandoffTest extends TestCase
     public function test_redeem_of_garbage_token_is_null(): void
     {
         $this->assertNull($this->handoff->redeem('nope'));
+    }
+
+    public function test_redemption_is_blocked_by_the_claim_even_if_payload_survives(): void
+    {
+        $url = $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertNotNull($this->handoff->redeem($query['token']));
+
+        // Simulate the get-then-forget race remnant: re-insert the payload.
+        Cache::store('array')->put('admin_sso:token:'.$query['token'], ['employee_id' => 1, 'name' => 'Ghost'], 60);
+
+        $this->assertNull($this->handoff->redeem($query['token']));
     }
 }

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use App\Saml\SamlLoginRejected;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdminSsoHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AdminSsoHandoff $handoff;
+
+    private SamlClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['saml.replay_store' => 'array', 'saml.admin_portal_url' => 'https://www.apexinnovations.com/admin']);
+
+        $this->handoff = app(AdminSsoHandoff::class);
+        $this->client = SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        DB::table('Employees')->insert([
+            'Email' => 'jane@apexinnovations.com', 'FirstName' => 'Jane', 'LastName' => 'Doe',
+            'Password' => md5('p6^8&irrelevant'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public function test_active_employee_gets_single_use_token(): void
+    {
+        $url = $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+
+        $this->assertStringStartsWith('https://www.apexinnovations.com/admin/ssoLogon.php?token=', $url);
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $this->assertSame(64, strlen($query['token']));
+
+        $payload = $this->handoff->redeem($query['token']);
+        $employeeId = DB::table('Employees')->where('Email', 'jane@apexinnovations.com')->value('ID');
+        $this->assertSame(['employee_id' => $employeeId, 'name' => 'Jane Doe'], $payload);
+
+        // single use
+        $this->assertNull($this->handoff->redeem($query['token']));
+    }
+
+    public function test_unknown_email_is_rejected(): void
+    {
+        $this->expectException(SamlLoginRejected::class);
+
+        try {
+            $this->handoff->initiate($this->client, 'stranger@apexinnovations.com');
+        } catch (SamlLoginRejected $e) {
+            $this->assertSame('no_employee_match', $e->logContext['reason']);
+            throw $e;
+        }
+    }
+
+    public function test_inactive_employee_is_rejected(): void
+    {
+        DB::table('Employees')->where('Email', 'jane@apexinnovations.com')->update(['Active' => 'N']);
+
+        $this->expectException(SamlLoginRejected::class);
+        $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+    }
+
+    public function test_redeem_of_garbage_token_is_null(): void
+    {
+        $this->assertNull($this->handoff->redeem('nope'));
+    }
+}

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -8,6 +8,7 @@ use App\Saml\SamlLoginRejected;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class AdminSsoHandoffTest extends TestCase
@@ -86,5 +87,14 @@ class AdminSsoHandoffTest extends TestCase
         Cache::store('array')->put('admin_sso:token:'.$query['token'], ['employee_id' => 1, 'name' => 'Ghost'], 60);
 
         $this->assertNull($this->handoff->redeem($query['token']));
+    }
+
+    public function test_failed_redemption_is_logged(): void
+    {
+        Log::spy();
+
+        $this->assertNull($this->handoff->redeem('unknown-token'));
+
+        Log::shouldHaveReceived('warning')->with('Admin SSO handoff redemption failed', ['already_claimed' => false]);
     }
 }

--- a/tests/Feature/ReferenceDataSeederTest.php
+++ b/tests/Feature/ReferenceDataSeederTest.php
@@ -45,4 +45,10 @@ class ReferenceDataSeederTest extends TestCase
         // Login, so the assertion survives dev-domain renames.)
         $this->assertDatabaseHas('Users', ['FirstName' => 'Dev', 'LastName' => 'User', 'DepartmentID' => 1]);
     }
+
+    public function test_seeder_creates_admin_portal_mock_client_and_employee(): void
+    {
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'local-admin-idp', 'admin_portal' => 1, 'enabled' => 0]);
+        $this->assertDatabaseHas('Employees', ['Email' => 'user1@example.com', 'Active' => 'Y']);
+    }
 }

--- a/tests/Feature/SamlClientCommandTest.php
+++ b/tests/Feature/SamlClientCommandTest.php
@@ -114,4 +114,34 @@ class SamlClientCommandTest extends TestCase
             ->expectsOutputToContain('acme.com')
             ->assertSuccessful();
     }
+
+    public function test_create_with_admin_portal_flag(): void
+    {
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933, '--admin-portal' => true,
+        ])->assertSuccessful();
+
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 1]);
+    }
+
+    public function test_admin_portal_client_cannot_claim_domains(): void
+    {
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933,
+            '--admin-portal' => true, '--domains' => 'apexinnovations.com',
+        ])->assertFailed();
+
+        $this->assertDatabaseMissing('saml_clients', ['slug' => 'apex-admin']);
+    }
+
+    public function test_update_can_toggle_admin_portal_off(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->artisan('saml:client', [
+            'action' => 'update', 'slug' => 'apex-admin', '--no-admin-portal' => true,
+        ])->assertSuccessful();
+
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 0]);
+    }
 }

--- a/tests/Feature/SamlClientModelTest.php
+++ b/tests/Feature/SamlClientModelTest.php
@@ -57,4 +57,25 @@ class SamlClientModelTest extends TestCase
 
         $this->assertNull(SamlClient::forEmailDomain('gmail.com'));
     }
+
+    public function test_admin_portal_defaults_to_false(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        $this->assertFalse($client->admin_portal);
+    }
+
+    public function test_admin_portal_state_sets_flag(): void
+    {
+        $client = SamlClient::factory()->adminPortal()->create();
+
+        $this->assertTrue($client->refresh()->admin_portal);
+    }
+
+    public function test_email_domain_lookup_never_matches_admin_portal_clients(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['email_domains' => ['apexinnovations.com']]);
+
+        $this->assertNull(SamlClient::forEmailDomain('apexinnovations.com'));
+    }
 }


### PR DESCRIPTION
> **⛔ DO NOT MERGE YET**
> 1. This branch is stacked on #40 (Milestone 4), which is stacked on #36 ← #27. Those must merge first, after which this one will be retargeted to `development`.
> 2. The portal side (SSO button, `ssoLogon.php`, admin-portal badge) lives in the `website_admin` repository — companion commits there, not yet pushed. Nothing breaks if this merges first: with no admin-portal client created, every code path here is inert.

## What this delivers

Bonus effort beyond the fixed-bid milestones: the admin portal itself can now sit behind SSO. Apex employees sign into `website_admin` through the company IdP instead of (or alongside) the portal's static-salted-MD5 password check — **feature-flagged so it can be switched on and off at runtime without a deploy**. Design spec: `docs/specs/2026-07-09-admin-portal-sso.md`.

### The flag

A new `admin_portal` boolean on `saml_clients` marks a client as asserting *Employee* identities (the portal's own auth table). The client's existing **`enabled` state is the feature flag**: `saml:client disable apex-admin` — or the toggle on the SSO Clients portal page — turns admin SSO off at runtime. The login/ACS endpoints already 404 disabled clients, and the portal's "Sign in with SSO" button hides itself within a minute (its visibility check is cached for 60s per session). No env vars, one source of truth.

Password login is untouched and coexists: if the IdP or the login app is down, admins still get in. Admin-portal clients can never claim email domains and are excluded from `/sso/lookup` routing at both write time (validation) and read time (query), so they cannot collide with customer SSO flows.

### The flow

1. Portal login form shows "Sign in with SSO" (when the flag is on) → `GET /saml/apex-admin/login` → IdP.
2. The ACS validates the assertion exactly as for customer clients (signature, replay guard, cert-expiry monitoring), then branches: match `Employees.Email` with `Active = 'Y'` — **fail closed, no JIT, no Users fallback, no Laravel session** — and mint a 60-second **single-use** handoff token (atomic claim-then-pull, so concurrent redemptions of one token are impossible; failed redemptions are logged with a replay-vs-expired distinction).
3. The browser lands on the portal's new `ssoLogon.php`, which redeems the token **server-to-server** through the same `ADMIN_API_TOKEN` bridge the SSO Clients page already uses — the browser-visible token is worthless without the server credential — then regenerates the session ID, sets the normal `AdminID`/`AdminName` session, and writes the same `AdminEvents` type-1 audit row as a password login (audit-insert failure = access denied, with the session torn down).
4. SSO sessions skip the 90-day password-expiry redirect — password age is meaningless for them. Password sessions keep the existing behavior exactly.

### Local dev + tests

- Second mock IdP container (`mock-idp-admin`, :8093) with a seeded `local-admin-idp` client and a matching Employee; `make db` fetches its metadata and enables it, same pattern as the existing mock.
- The SSO Clients portal page now shows a read-only "Admin portal" badge on such clients (companion `website_admin` commit, bundle rebuilt).
- Onboarding runbook gained an "Admin portal SSO" section: mechanics, flag semantics, rollout, and the new `no_employee_match` troubleshooting row.

## Rollout (each step inert)

1. Merge/deploy this (migration is additive; `migrations_login` auto-migrate handles it) — nothing changes, no admin client exists.
2. Deploy `website_admin` — button hidden (flag off), `ssoLogon.php` unreachable without a token.
3. `saml:client create --name="Apex Admin" --org=<org> --admin-portal`, apply the internal IdP's metadata, verify with a test employee, `enable`. Set `LOGIN_SSO_CLIENT=apex-admin` in the portal env.
4. Switch off any time: `saml:client disable apex-admin` or the portal toggle.

## Verification

- 181 backend tests passing (new coverage: flag plumbing end-to-end, ACS Employees matching incl. inactive/unknown/no-Users-row, token mint/redeem/replay/expiry, redeem endpoint auth, domain-claim rejection, lookup exclusion, seeders)
- 8 Dusk browser tests green twice in a row, including the full round trip: portal button → mock IdP login → authenticated `Home.php`, plus the flag-off case (button gone, login endpoint 404s)
- Live curl verification of `ssoLogon.php`: happy path, garbage token, replayed token, and the `AdminEvents` audit row

Known accepted limitation (documented): the handoff token isn't bound to the initiating browser, so the standard login-CSRF caveat of stateless SSO callbacks applies (insider-only, low impact); RelayState/nonce binding is the eventual hardening if wanted.
