### PR TITLE
Milestones 4+5: SSO admin tools, admin portal SSO, and attribute-based routing

### DIFF
--- a/.Dockerfile-php
+++ b/.Dockerfile-php
@@ -2,3 +2,9 @@ FROM 685265542736.dkr.ecr.us-east-1.amazonaws.com/base-php-fpm
 COPY --chown=www-data:www-data . /var/www/html/
 COPY .php.ini /usr/local/etc/php/conf.d/apex-php.ini
 COPY .env.empty /var/www/html/.env
+# Migrate-on-start: history is isolated in migrations_login, so this is safe
+# against the shared database. CMD assumes the base image serves via php-fpm.
+COPY .docker-entrypoint.sh /usr/local/bin/login-entrypoint.sh
+RUN chmod +x /usr/local/bin/login-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/login-entrypoint.sh"]
+CMD ["php-fpm"]

--- a/.docker-entrypoint.sh
+++ b/.docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Runs pending migrations before the app serves. Safe against the shared
+# database because migration history is tracked in this app's own table
+# (config/database.php 'migrations' => 'migrations_login'), and safe against
+# concurrent task launches via --isolated (cache lock). A migration failure
+# exits non-zero so ECS keeps the previous tasks serving.
+#
+# The local schema dump (database/schema/mysql-schema.sql) is deliberately
+# absent from this image (.dockerignore-php ships only *.php), so migrate
+# never attempts a schema load here — it only applies real migrations.
+set -e
+
+cd /var/www/html
+php artisan migrate --force --isolated
+
+exec "$@"

--- a/.dockerignore-php
+++ b/.dockerignore-php
@@ -14,6 +14,11 @@
 !.env.empty
 !*.ini
 
+# Migrate-on-start entrypoint (see .Dockerfile-php) — artisan has no .php
+# extension so it needs its own allowlist entry or the image can't migrate
+!.docker-entrypoint.sh
+!artisan
+
 # And not vendor directories
 !**/vendor/
 !**/vendor/**/*

--- a/.env.dev
+++ b/.env.dev
@@ -56,6 +56,10 @@ FORWARD_MAILHOG_DASHBOARD_PORT=18025
 WEBSITE_PORT=8091
 MYCURRICULUM_URL=http://localhost:8091/MyCurriculum.php
 
+# Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
+# No port: the admin session cookie only survives on http://localhost/admin.
+ADMIN_PORTAL_URL=http://localhost/admin
+
 WWWUSER=1000
 WWWGROUP=1000
 

--- a/.env.dev
+++ b/.env.dev
@@ -89,3 +89,7 @@ MOCK_IDP_PORT=8092
 # drop the cookie. See the website service's WEBSITE_ADMIN_PORT mapping.
 DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
+
+# Admin API bridge (website_admin SSOClients.php -> this app's admin API).
+# Must match LOGIN_ADMIN_API_TOKEN in docker/website.env.dev.
+ADMIN_API_TOKEN=local-dev-admin-token

--- a/.env.dev
+++ b/.env.dev
@@ -79,3 +79,13 @@ CREATEACCOUNT_URL=http://localhost:8091/CreateAccountLanding.php
 # SAML SP configuration
 SAML_SP_ENTITY_ID=http://localhost:8090/saml/metadata
 MOCK_IDP_PORT=8092
+
+# Dusk browser tests: selenium runs with network_mode: host, so its Chrome
+# reaches the apps at http://localhost:809x; the login container reaches
+# selenium via the extra_hosts host-gateway. DUSK_ADMIN_URL uses bare
+# :80 (no port) — website_admin/SESSIONCONFIG.php puts $_SERVER['HTTP_HOST']
+# verbatim into the admin session cookie's Domain when the host matches
+# /local/i, and a port in that value makes the Domain invalid, so browsers
+# drop the cookie. See the website service's WEBSITE_ADMIN_PORT mapping.
+DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
+DUSK_ADMIN_URL=http://localhost/admin

--- a/.env.dev
+++ b/.env.dev
@@ -83,6 +83,7 @@ CREATEACCOUNT_URL=http://localhost:8091/CreateAccountLanding.php
 # SAML SP configuration
 SAML_SP_ENTITY_ID=http://localhost:8090/saml/metadata
 MOCK_IDP_PORT=8092
+MOCK_IDP_ADMIN_PORT=8093
 
 # Dusk browser tests: selenium runs with network_mode: host, so its Chrome
 # reaches the apps at http://localhost:809x; the login container reaches

--- a/.env.example
+++ b/.env.example
@@ -53,4 +53,7 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
 
+# Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
+ADMIN_PORTAL_URL=
+
 ADMIN_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
 
 # Browser-facing URL of the legacy admin portal (SSO handoff redirect target).
-ADMIN_PORTAL_URL=
+# Defaults to the production portal when unset.
+# ADMIN_PORTAL_URL=
 
 ADMIN_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,5 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
 DUSK_ADMIN_URL=http://localhost/admin
+
+ADMIN_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,6 @@ PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+DUSK_DRIVER_URL=http://host.docker.internal:4444/wd/hub
+DUSK_ADMIN_URL=http://localhost/admin

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+/tests/Browser/console
+/tests/Browser/screenshots
+/tests/Browser/source

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXEC         = $(COMPOSE) exec -T login
 WEBSITE_ROOT = ../website_root
 COMPOSER_IMG = docker run --rm --entrypoint sh -v $(CURDIR)/..:/repos composer:2 -c
 
-.PHONY: help setup env deps up db users test e2e lint fix down destroy logs
+.PHONY: help setup env deps up db users test dusk e2e lint fix down destroy logs
 
 help:
 	@echo "Targets:"
@@ -20,6 +20,7 @@ help:
 	@echo "  db       migrate:fresh, seed, and create the local user hierarchy"
 	@echo "  users    (re)run the local user hierarchy command only"
 	@echo "  test     run the phpunit suite (MySQL test database)"
+	@echo "  dusk     run Laravel Dusk browser tests (needs 'make db' state + selenium up)"
 	@echo "  lint     check code style (pint --test)"
 	@echo "  fix      fix code style (pint)"
 	@echo "  e2e      run the login -> MyCurriculum session handoff test"
@@ -64,6 +65,9 @@ users:
 
 test:
 	$(EXEC) php artisan test
+
+dusk:
+	$(EXEC) php artisan dusk
 
 lint:
 	$(EXEC) vendor/bin/pint --test

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ db:
 		&& php artisan saml:client update local-idp --metadata=/tmp/mock-idp-metadata.xml \
 		&& php artisan saml:client enable local-idp" \
 		|| echo "mock-idp not reachable; SAML client left disabled (run 'docker compose up -d mock-idp' then 'make db')"
+	$(EXEC) sh -c "curl -sf -H 'Host: localhost:$${MOCK_IDP_ADMIN_PORT:-8093}' http://mock-idp-admin:8080/simplesaml/saml2/idp/metadata.php -o /tmp/mock-idp-admin-metadata.xml \
+		&& php artisan saml:client update local-admin-idp --metadata=/tmp/mock-idp-admin-metadata.xml \
+		&& php artisan saml:client enable local-admin-idp" \
+		|| echo "mock-idp-admin not reachable; admin SSO client left disabled (run 'docker compose up -d mock-idp-admin' then 'make db')"
 
 users:
 	$(EXEC) php artisan local:users

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,12 @@ up:
 	$(COMPOSE) up -d --build
 
 db:
-	$(EXEC) php artisan migrate:fresh --seed
+	# Wipe explicitly instead of migrate:fresh: fresh only wipes when the
+	# migration repository table exists, and ours is the app-specific
+	# migrations_login (shared prod DB) — on a DB built before the rename,
+	# fresh would skip the wipe and collide with the schema dump.
+	$(EXEC) php artisan db:wipe --force
+	$(EXEC) php artisan migrate --seed
 	$(EXEC) php artisan local:users
 	$(EXEC) sh -c "curl -sf -H 'Host: localhost:$${MOCK_IDP_PORT:-8092}' http://mock-idp:8080/simplesaml/saml2/idp/metadata.php -o /tmp/mock-idp-metadata.xml \
 		&& php artisan saml:client update local-idp --metadata=/tmp/mock-idp-metadata.xml \

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -28,6 +28,8 @@ class SamlClientCommand extends Command
         {--no-jit : disable just-in-time provisioning}
         {--metadata= : path to an IdP metadata XML file}
         {--domains= : comma-separated email domains for SP-initiated SSO routing (replaces the list)}
+        {--admin-portal : mark the client as asserting admin-portal (Employee) identities}
+        {--no-admin-portal : clear the admin-portal marker}
         {--wizard : create a client interactively (create action only)}';
 
     protected $description = 'Manage SAML SSO client configurations';
@@ -76,6 +78,7 @@ class SamlClientCommand extends Command
                 $client->name,
                 $client->enabled ? 'yes' : 'no',
                 $client->jit_enabled ? 'yes' : 'no',
+                $client->admin_portal ? 'yes' : '',
                 $client->organization_id,
                 $client->department_id ?? '-',
                 implode(', ', $client->email_domains ?? []),
@@ -84,7 +87,7 @@ class SamlClientCommand extends Command
             ];
         });
 
-        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Org', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
+        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Admin', 'Org', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
 
         return self::SUCCESS;
     }
@@ -98,6 +101,7 @@ class SamlClientCommand extends Command
         $this->line("Slug: {$client->slug}");
         $this->line('Enabled: '.($client->enabled ? 'yes' : 'no'));
         $this->line('JIT provisioning: '.($client->jit_enabled ? 'yes' : 'no'));
+        $this->line('Admin portal: '.($client->admin_portal ? 'yes' : 'no'));
         $this->line("Organization ID: {$client->organization_id}");
         $this->line('Department ID: '.($client->department_id ?? 'none (users select their department at finish-account)'));
         $this->line('Email domains: '.(implode(', ', $client->email_domains ?? []) ?: 'none (IdP-initiated only)'));
@@ -126,6 +130,10 @@ class SamlClientCommand extends Command
 
         if (! $this->option('wizard') && ($domains = $this->domainsOption()) !== null) {
             $input['email_domains'] = $domains;
+        }
+
+        if (! $this->option('wizard') && $this->option('admin-portal')) {
+            $input['admin_portal'] = true;
         }
 
         $client = $manager->create($input);
@@ -266,6 +274,12 @@ class SamlClientCommand extends Command
         }
         if ($this->option('no-jit')) {
             $client = $manager->update($client, ['jit_enabled' => false]);
+        }
+        if ($this->option('admin-portal')) {
+            $client = $manager->update($client, ['admin_portal' => true]);
+        }
+        if ($this->option('no-admin-portal')) {
+            $client = $manager->update($client, ['admin_portal' => false]);
         }
 
         return $client;

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -140,13 +140,9 @@ class SamlClientCommand extends Command
                 'department_id' => $this->option('department'),
             ], fn ($v) => $v !== null);
 
-            $owner = $this->ownerOptionPair();
-
-            if ($owner === null) {
+            if (! $this->mergeOwnerOption($input)) {
                 return $this->failWith('Provide exactly one of --org or --system.');
             }
-
-            $input += $owner;
         }
 
         if (! $this->option('wizard') && ($domains = $this->domainsOption()) !== null) {
@@ -267,13 +263,9 @@ class SamlClientCommand extends Command
         ], fn ($v) => $v !== null);
 
         if ($this->option('org') !== null || $this->option('system') !== null) {
-            $owner = $this->ownerOptionPair();
-
-            if ($owner === null) {
+            if (! $this->mergeOwnerOption($fields)) {
                 return $this->failWith('Provide exactly one of --org or --system.');
             }
-
-            $fields += $owner;
         }
 
         if ($this->option('no-department') && $this->option('department') !== null) {
@@ -450,28 +442,31 @@ class SamlClientCommand extends Command
     }
 
     /**
-     * Resolve --org/--system into an owner_type/owner_id pair, shared by
-     * create (where exactly one is required) and update (where re-parenting
-     * is optional, but both is still an error). Both call sites emit the
-     * same "Provide exactly one of --org or --system." failure via
-     * failWith() when this returns null; neither call site distinguishes
-     * "neither given" from "both given" in the message.
+     * Resolve --org/--system into an owner_type/owner_id pair and merge it
+     * into $input, shared by create (where exactly one is required) and
+     * update (where re-parenting is optional, but both is still an error).
+     * Both call sites emit the same "Provide exactly one of --org or
+     * --system." failure via failWith() when this returns false; neither
+     * call site distinguishes "neither given" from "both given" in the
+     * message.
      *
-     * @return array{owner_type: string, owner_id: string}|null
+     * @param  array<string, mixed>  $input
      */
-    private function ownerOptionPair(): ?array
+    private function mergeOwnerOption(array &$input): bool
     {
         $org = $this->option('org');
         $system = $this->option('system');
 
         if (($org === null) === ($system === null)) {
-            return null;
+            return false;
         }
 
-        return [
+        $input += [
             'owner_type' => $org !== null ? 'organization' : 'system',
             'owner_id' => $org ?? $system,
         ];
+
+        return true;
     }
 
     /**

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -79,7 +79,7 @@ class SamlClientCommand extends Command
                 $client->enabled ? 'yes' : 'no',
                 $client->jit_enabled ? 'yes' : 'no',
                 $client->admin_portal ? 'yes' : '',
-                $client->organization_id,
+                $client->owner_id,
                 $client->department_id ?? '-',
                 implode(', ', $client->email_domains ?? []),
                 $cert['expires_at']?->toDateString() ?? '-',
@@ -102,7 +102,7 @@ class SamlClientCommand extends Command
         $this->line('Enabled: '.($client->enabled ? 'yes' : 'no'));
         $this->line('JIT provisioning: '.($client->jit_enabled ? 'yes' : 'no'));
         $this->line('Admin portal: '.($client->admin_portal ? 'yes' : 'no'));
-        $this->line("Organization ID: {$client->organization_id}");
+        $this->line("Organization ID: {$client->owner_id}");
         $this->line('Department ID: '.($client->department_id ?? 'none (users select their department at finish-account)'));
         $this->line('Email domains: '.(implode(', ', $client->email_domains ?? []) ?: 'none (IdP-initiated only)'));
         $this->line('ACS URL: '.$client->acsUrl());
@@ -124,7 +124,7 @@ class SamlClientCommand extends Command
             : array_filter([
                 'name' => $this->option('name'),
                 'slug' => $this->option('slug'),
-                'organization_id' => $this->option('org'),
+                'owner_id' => $this->option('org'),
                 'department_id' => $this->option('department'),
             ], fn ($v) => $v !== null);
 
@@ -154,7 +154,7 @@ class SamlClientCommand extends Command
     /**
      * Gather client-creation input interactively.
      *
-     * @return array{name: string, slug: string, organization_id: int,
+     * @return array{name: string, slug: string, owner_id: int,
      *               department_id: int|null, jit_enabled: bool, attribute_map?: array}
      */
     private function runWizard(): array
@@ -191,7 +191,7 @@ class SamlClientCommand extends Command
         $input = [
             'name' => $name,
             'slug' => $slug,
-            'organization_id' => $organizationId,
+            'owner_id' => $organizationId,
             'department_id' => $departmentId,
             'jit_enabled' => $jit,
         ];
@@ -225,7 +225,7 @@ class SamlClientCommand extends Command
 
         $fields = array_filter([
             'name' => $this->option('name'),
-            'organization_id' => $this->option('org'),
+            'owner_id' => $this->option('org'),
             'department_id' => $this->option('department'),
         ], fn ($v) => $v !== null);
 

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use App\Saml\SamlClientManager;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
@@ -13,6 +14,7 @@ use InvalidArgumentException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\search;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
 class SamlClientCommand extends Command
@@ -22,7 +24,8 @@ class SamlClientCommand extends Command
         {slug? : client slug (all actions except list/create)}
         {--name= : display name}
         {--slug= : explicit slug (create only; defaults to slugged name)}
-        {--org= : Apex organization ID}
+        {--org= : owning organization ID (exactly one of --org/--system)}
+        {--system= : owning system ID (exactly one of --org/--system)}
         {--department= : default department ID (omit for the finish-account flow)}
         {--jit : enable just-in-time provisioning}
         {--no-jit : disable just-in-time provisioning}
@@ -79,7 +82,7 @@ class SamlClientCommand extends Command
                 $client->enabled ? 'yes' : 'no',
                 $client->jit_enabled ? 'yes' : 'no',
                 $client->admin_portal ? 'yes' : '',
-                $client->owner_id,
+                ($client->ownedByOrganization() ? 'org #' : 'system #').$client->owner_id,
                 $client->department_id ?? '-',
                 implode(', ', $client->email_domains ?? []),
                 $cert['expires_at']?->toDateString() ?? '-',
@@ -87,7 +90,7 @@ class SamlClientCommand extends Command
             ];
         });
 
-        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Admin', 'Org', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
+        $this->table(['Slug', 'Name', 'Enabled', 'JIT', 'Admin', 'Owner', 'Dept', 'Domains', 'Cert expires', ''], $rows->all());
 
         return self::SUCCESS;
     }
@@ -102,7 +105,7 @@ class SamlClientCommand extends Command
         $this->line('Enabled: '.($client->enabled ? 'yes' : 'no'));
         $this->line('JIT provisioning: '.($client->jit_enabled ? 'yes' : 'no'));
         $this->line('Admin portal: '.($client->admin_portal ? 'yes' : 'no'));
-        $this->line("Organization ID: {$client->owner_id}");
+        $this->line('Owner: '.$client->owner_type.' '.$client->owner_id.' ('.($client->ownerName() ?? 'unknown').')');
         $this->line('Department ID: '.($client->department_id ?? 'none (users select their department at finish-account)'));
         $this->line('Email domains: '.(implode(', ', $client->email_domains ?? []) ?: 'none (IdP-initiated only)'));
         $this->line('ACS URL: '.$client->acsUrl());
@@ -119,14 +122,25 @@ class SamlClientCommand extends Command
 
     private function createClient(SamlClientManager $manager): int
     {
-        $input = $this->option('wizard')
-            ? $this->runWizard()
-            : array_filter([
+        if ($this->option('wizard')) {
+            $input = $this->runWizard();
+        } else {
+            $input = array_filter([
                 'name' => $this->option('name'),
                 'slug' => $this->option('slug'),
-                'owner_id' => $this->option('org'),
                 'department_id' => $this->option('department'),
             ], fn ($v) => $v !== null);
+
+            $org = $this->option('org');
+            $system = $this->option('system');
+
+            if (($org === null) === ($system === null)) {
+                return $this->failWith('Provide exactly one of --org or --system.');
+            }
+
+            $input['owner_type'] = $org !== null ? 'organization' : 'system';
+            $input['owner_id'] = $org ?? $system;
+        }
 
         if (! $this->option('wizard') && ($domains = $this->domainsOption()) !== null) {
             $input['email_domains'] = $domains;
@@ -154,7 +168,7 @@ class SamlClientCommand extends Command
     /**
      * Gather client-creation input interactively.
      *
-     * @return array{name: string, slug: string, owner_id: int,
+     * @return array{name: string, slug: string, owner_type: string, owner_id: int,
      *               department_id: int|null, jit_enabled: bool, attribute_map?: array}
      */
     private function runWizard(): array
@@ -170,18 +184,34 @@ class SamlClientCommand extends Command
             required: true,
         );
 
-        $organizationId = (int) search(
-            label: 'Organization',
-            options: fn (string $value) => $this->wizardOrganizationOptions($value),
-            placeholder: 'Type to search organizations',
+        $ownerType = select(
+            label: 'Owned by',
+            options: ['organization' => 'Organization', 'system' => 'System (spans its organizations)'],
+            default: 'organization',
         );
 
-        $departmentChoice = search(
-            label: 'Default department',
-            options: fn (string $value) => $this->wizardDepartmentOptions($organizationId, $value),
-            placeholder: 'Type to search, or choose None',
-        );
-        $departmentId = $departmentChoice === self::NO_DEPARTMENT ? null : (int) $departmentChoice;
+        if ($ownerType === 'system') {
+            $ownerId = (int) search(
+                label: 'System',
+                options: fn (string $value) => $this->wizardSystemOptions($value),
+                placeholder: 'Type to search systems',
+            );
+
+            $departmentId = null;
+        } else {
+            $ownerId = (int) search(
+                label: 'Organization',
+                options: fn (string $value) => $this->wizardOrganizationOptions($value),
+                placeholder: 'Type to search organizations',
+            );
+
+            $departmentChoice = search(
+                label: 'Default department',
+                options: fn (string $value) => $this->wizardDepartmentOptions($ownerId, $value),
+                placeholder: 'Type to search, or choose None',
+            );
+            $departmentId = $departmentChoice === self::NO_DEPARTMENT ? null : (int) $departmentChoice;
+        }
 
         $jit = confirm(
             label: 'Auto-create unknown users on first login?',
@@ -191,7 +221,8 @@ class SamlClientCommand extends Command
         $input = [
             'name' => $name,
             'slug' => $slug,
-            'owner_id' => $organizationId,
+            'owner_type' => $ownerType,
+            'owner_id' => $ownerId,
             'department_id' => $departmentId,
             'jit_enabled' => $jit,
         ];
@@ -225,9 +256,20 @@ class SamlClientCommand extends Command
 
         $fields = array_filter([
             'name' => $this->option('name'),
-            'owner_id' => $this->option('org'),
             'department_id' => $this->option('department'),
         ], fn ($v) => $v !== null);
+
+        $org = $this->option('org');
+        $system = $this->option('system');
+
+        if ($org !== null || $system !== null) {
+            if ($org !== null && $system !== null) {
+                return $this->failWith('Provide exactly one of --org or --system.');
+            }
+
+            $fields['owner_type'] = $org !== null ? 'organization' : 'system';
+            $fields['owner_id'] = $org ?? $system;
+        }
 
         if (($domains = $this->domainsOption()) !== null) {
             $fields['email_domains'] = $domains;
@@ -318,6 +360,19 @@ class SamlClientCommand extends Command
     protected function wizardOrganizationOptions(string $search): array
     {
         return Organization::query()
+            ->when($search !== '', fn ($q) => $q->where('Name', 'like', '%'.$search.'%'))
+            ->orderBy('Name')
+            ->limit(25)
+            ->pluck('Name', 'ID')
+            ->all();
+    }
+
+    /**
+     * @return array<int, string> Systems.ID => Name, filtered by search.
+     */
+    protected function wizardSystemOptions(string $search): array
+    {
+        return System::query()
             ->when($search !== '', fn ($q) => $q->where('Name', 'like', '%'.$search.'%'))
             ->orderBy('Name')
             ->limit(25)

--- a/app/Console/Commands/SamlClientCommand.php
+++ b/app/Console/Commands/SamlClientCommand.php
@@ -5,6 +5,8 @@ namespace App\Console\Commands;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
 use App\Models\System;
 use App\Saml\SamlClientManager;
 use Illuminate\Console\Command;
@@ -20,20 +22,24 @@ use function Laravel\Prompts\text;
 class SamlClientCommand extends Command
 {
     protected $signature = 'saml:client
-        {action : list, describe, create, update, enable, or disable}
+        {action : list, describe, create, update, enable, disable, or routing}
         {slug? : client slug (all actions except list/create)}
         {--name= : display name}
         {--slug= : explicit slug (create only; defaults to slugged name)}
         {--org= : owning organization ID (exactly one of --org/--system)}
         {--system= : owning system ID (exactly one of --org/--system)}
         {--department= : default department ID (omit for the finish-account flow)}
+        {--no-department : clear the default department (update only; conflicts with --department)}
         {--jit : enable just-in-time provisioning}
         {--no-jit : disable just-in-time provisioning}
         {--metadata= : path to an IdP metadata XML file}
         {--domains= : comma-separated email domains for SP-initiated SSO routing (replaces the list)}
         {--admin-portal : mark the client as asserting admin-portal (Employee) identities}
         {--no-admin-portal : clear the admin-portal marker}
-        {--wizard : create a client interactively (create action only)}';
+        {--wizard : create a client interactively (create action only)}
+        {--set= : inline JSON object with org_rules/department_rules keys (routing action only)}
+        {--set-file= : path to a JSON file with org_rules/department_rules keys (routing action only)}
+        {--clear : replace routing rules with empty lists (routing action only)}';
 
     protected $description = 'Manage SAML SSO client configurations';
 
@@ -54,7 +60,8 @@ class SamlClientCommand extends Command
                 'update' => $this->updateClient($manager),
                 'enable' => $this->toggle($manager, true),
                 'disable' => $this->toggle($manager, false),
-                default => $this->failWith('Unknown action. Use: list, describe, create, update, enable, disable.'),
+                'routing' => $this->routingAction($manager),
+                default => $this->failWith('Unknown action. Use: list, describe, create, update, enable, disable, routing.'),
             };
         } catch (ValidationException $e) {
             foreach ($e->errors() as $messages) {
@@ -116,6 +123,8 @@ class SamlClientCommand extends Command
         if ($cert['expiring']) {
             $this->warn('IdP certificate is expiring soon!');
         }
+        $this->line('Org rules: '.$client->orgRules()->count());
+        $this->line('Department rules: '.$client->departmentRules()->count());
 
         return self::SUCCESS;
     }
@@ -131,15 +140,13 @@ class SamlClientCommand extends Command
                 'department_id' => $this->option('department'),
             ], fn ($v) => $v !== null);
 
-            $org = $this->option('org');
-            $system = $this->option('system');
+            $owner = $this->ownerOptionPair();
 
-            if (($org === null) === ($system === null)) {
+            if ($owner === null) {
                 return $this->failWith('Provide exactly one of --org or --system.');
             }
 
-            $input['owner_type'] = $org !== null ? 'organization' : 'system';
-            $input['owner_id'] = $org ?? $system;
+            $input += $owner;
         }
 
         if (! $this->option('wizard') && ($domains = $this->domainsOption()) !== null) {
@@ -259,16 +266,22 @@ class SamlClientCommand extends Command
             'department_id' => $this->option('department'),
         ], fn ($v) => $v !== null);
 
-        $org = $this->option('org');
-        $system = $this->option('system');
+        if ($this->option('org') !== null || $this->option('system') !== null) {
+            $owner = $this->ownerOptionPair();
 
-        if ($org !== null || $system !== null) {
-            if ($org !== null && $system !== null) {
+            if ($owner === null) {
                 return $this->failWith('Provide exactly one of --org or --system.');
             }
 
-            $fields['owner_type'] = $org !== null ? 'organization' : 'system';
-            $fields['owner_id'] = $org ?? $system;
+            $fields += $owner;
+        }
+
+        if ($this->option('no-department') && $this->option('department') !== null) {
+            return $this->failWith('Provide --department or --no-department, not both.');
+        }
+
+        if ($this->option('no-department')) {
+            $fields['department_id'] = null;
         }
 
         if (($domains = $this->domainsOption()) !== null) {
@@ -309,6 +322,115 @@ class SamlClientCommand extends Command
         return self::SUCCESS;
     }
 
+    private function routingAction(SamlClientManager $manager): int
+    {
+        $client = $this->resolveClient();
+        if (! $client) {
+            return self::FAILURE;
+        }
+
+        if ($this->option('clear') || $this->option('set') !== null || $this->option('set-file') !== null) {
+            return $this->replaceRoutingRules($manager, $client);
+        }
+
+        $this->renderRoutingRules($client);
+
+        return self::SUCCESS;
+    }
+
+    private function replaceRoutingRules(SamlClientManager $manager, SamlClient $client): int
+    {
+        if ($this->option('clear')) {
+            $orgRules = [];
+            $departmentRules = [];
+        } else {
+            $json = $this->option('set') !== null
+                ? $this->option('set')
+                : $this->readSetFile((string) $this->option('set-file'));
+
+            if ($json === null) {
+                return self::FAILURE;
+            }
+
+            $decoded = json_decode($json, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE || ! is_array($decoded)) {
+                $this->error('Invalid JSON: '.json_last_error_msg());
+
+                return self::FAILURE;
+            }
+
+            $orgRules = $decoded['org_rules'] ?? [];
+            $departmentRules = $decoded['department_rules'] ?? [];
+        }
+
+        $manager->replaceRoutingRules($client, $orgRules, $departmentRules);
+
+        $this->info("Routing rules replaced for {$client->slug}.");
+
+        return self::SUCCESS;
+    }
+
+    private function readSetFile(string $path): ?string
+    {
+        if (! is_file($path)) {
+            $this->error("Routing rules file not found: $path");
+
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            $this->error("Could not read routing rules file: $path");
+
+            return null;
+        }
+
+        return $contents;
+    }
+
+    private function renderRoutingRules(SamlClient $client): void
+    {
+        $orgRules = $client->orgRules;
+        $departmentRules = $client->departmentRules;
+
+        if ($orgRules->isEmpty()) {
+            $this->line('Org rules: none');
+        } else {
+            $orgNames = Organization::whereIn('ID', $orgRules->pluck('organization_id')->unique())->pluck('Name', 'ID');
+
+            $this->line('Org rules:');
+            foreach ($orgRules as $index => $rule) {
+                $orgLabel = ($orgNames->get($rule->organization_id) ?? 'unknown')." ({$rule->organization_id})";
+                $this->line('org '.($index + 1).'. '.$this->describeRuleSentence($rule, $orgLabel));
+            }
+        }
+
+        if ($departmentRules->isEmpty()) {
+            $this->line('Department rules: none');
+        } else {
+            $this->line('Department rules:');
+            foreach ($departmentRules as $index => $rule) {
+                $this->line('dept '.($index + 1).'. '.$this->describeRuleSentence($rule, "\"{$rule->department_name}\""));
+            }
+        }
+    }
+
+    /**
+     * @param  SamlOrgRule|SamlDepartmentRule  $rule
+     */
+    private function describeRuleSentence($rule, string $target): string
+    {
+        if ($rule->isCatchAll()) {
+            return 'everyone →';
+        }
+
+        $operator = str_replace('_', ' ', $rule->operator->value);
+
+        return "{$rule->attribute} {$operator} \"{$rule->value}\" → {$target}";
+    }
+
     private function applyCommonOptions(SamlClientManager $manager, SamlClient $client): SamlClient
     {
         if ($this->option('jit')) {
@@ -325,6 +447,31 @@ class SamlClientCommand extends Command
         }
 
         return $client;
+    }
+
+    /**
+     * Resolve --org/--system into an owner_type/owner_id pair, shared by
+     * create (where exactly one is required) and update (where re-parenting
+     * is optional, but both is still an error). Both call sites emit the
+     * same "Provide exactly one of --org or --system." failure via
+     * failWith() when this returns null; neither call site distinguishes
+     * "neither given" from "both given" in the message.
+     *
+     * @return array{owner_type: string, owner_id: string}|null
+     */
+    private function ownerOptionPair(): ?array
+    {
+        $org = $this->option('org');
+        $system = $this->option('system');
+
+        if (($org === null) === ($system === null)) {
+            return null;
+        }
+
+        return [
+            'owner_type' => $org !== null ? 'organization' : 'system',
+            'owner_id' => $org ?? $system,
+        ];
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/Concerns/ResolvesSamlClientBySlug.php
+++ b/app/Http/Controllers/Api/Admin/Concerns/ResolvesSamlClientBySlug.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin\Concerns;
+
+use App\Models\SamlClient;
+
+trait ResolvesSamlClientBySlug
+{
+    private function resolve(string $slug): SamlClient
+    {
+        $client = SamlClient::where('slug', $slug)->first();
+
+        abort_if($client === null, 404);
+
+        return $client;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/LookupController.php
+++ b/app/Http/Controllers/Api/Admin/LookupController.php
@@ -54,7 +54,7 @@ class LookupController extends Controller
 
         $q = (string) $request->query('q', '');
 
-        $departmentIds = Department::where('OrganizationID', $client->organization_id)->pluck('ID');
+        $departmentIds = Department::where('OrganizationID', $client->owner_id)->pluck('ID');
 
         return response()->json([
             'data' => User::query()

--- a/app/Http/Controllers/Api/Admin/LookupController.php
+++ b/app/Http/Controllers/Api/Admin/LookupController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Read-only pickers for the admin UI. Lookups, not writes — no manager
+ * involvement, no audit (GETs are unaudited by design).
+ */
+class LookupController extends Controller
+{
+    public function organizations(Request $request): JsonResponse
+    {
+        $q = (string) $request->query('q', '');
+
+        return response()->json([
+            'data' => Organization::query()
+                ->when($q !== '', fn ($query) => $query->where('Name', 'like', '%'.$q.'%'))
+                ->orderBy('Name')
+                ->limit(25)
+                ->get()
+                ->map(fn (Organization $org) => ['id' => $org->ID, 'name' => $org->Name])
+                ->values(),
+        ]);
+    }
+
+    public function departments(int $organizationId): JsonResponse
+    {
+        return response()->json([
+            'data' => Department::query()
+                ->where('OrganizationID', $organizationId)
+                ->where('Active', 'Y')
+                ->orderBy('Name')
+                ->get()
+                ->map(fn (Department $dept) => ['id' => $dept->ID, 'name' => $dept->Name])
+                ->values(),
+        ]);
+    }
+
+    public function users(Request $request, string $slug): JsonResponse
+    {
+        $client = SamlClient::where('slug', $slug)->first();
+
+        abort_if($client === null, 404);
+
+        $q = (string) $request->query('q', '');
+
+        $departmentIds = Department::where('OrganizationID', $client->organization_id)->pluck('ID');
+
+        return response()->json([
+            'data' => User::query()
+                ->whereIn('DepartmentID', $departmentIds)
+                ->when($q !== '', fn ($query) => $query->where(function ($inner) use ($q) {
+                    $inner->where('Login', 'like', '%'.$q.'%')
+                        ->orWhere('FirstName', 'like', '%'.$q.'%')
+                        ->orWhere('LastName', 'like', '%'.$q.'%');
+                }))
+                ->with('department')
+                ->orderBy('LastName')
+                ->limit(25)
+                ->get()
+                ->map(fn (User $user) => [
+                    'login' => $user->Login,
+                    'first_name' => $user->FirstName,
+                    'last_name' => $user->LastName,
+                    'department' => $user->department?->Name,
+                ])
+                ->values(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/LookupController.php
+++ b/app/Http/Controllers/Api/Admin/LookupController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -54,7 +55,7 @@ class LookupController extends Controller
 
         $q = (string) $request->query('q', '');
 
-        $departmentIds = Department::where('OrganizationID', $client->owner_id)->pluck('ID');
+        $departmentIds = Department::whereIn('OrganizationID', $client->scopedOrganizationIds())->pluck('ID');
 
         return response()->json([
             'data' => User::query()
@@ -74,6 +75,21 @@ class LookupController extends Controller
                     'last_name' => $user->LastName,
                     'department' => $user->department?->Name,
                 ])
+                ->values(),
+        ]);
+    }
+
+    public function systems(Request $request): JsonResponse
+    {
+        $q = (string) $request->query('q', '');
+
+        return response()->json([
+            'data' => System::query()
+                ->when($q !== '', fn ($query) => $query->where('Name', 'like', '%'.$q.'%'))
+                ->orderBy('Name')
+                ->limit(25)
+                ->get()
+                ->map(fn (System $system) => ['id' => $system->ID, 'name' => $system->Name])
                 ->values(),
         ]);
     }

--- a/app/Http/Controllers/Api/Admin/LookupController.php
+++ b/app/Http/Controllers/Api/Admin/LookupController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Admin\Concerns\ResolvesSamlClientBySlug;
 use App\Http\Controllers\Controller;
 use App\Models\Department;
 use App\Models\Organization;
-use App\Models\SamlClient;
 use App\Models\System;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
@@ -17,6 +17,8 @@ use Illuminate\Http\Request;
  */
 class LookupController extends Controller
 {
+    use ResolvesSamlClientBySlug;
+
     public function organizations(Request $request): JsonResponse
     {
         $q = (string) $request->query('q', '');
@@ -49,9 +51,7 @@ class LookupController extends Controller
 
     public function users(Request $request, string $slug): JsonResponse
     {
-        $client = SamlClient::where('slug', $slug)->first();
-
-        abort_if($client === null, 404);
+        $client = $this->resolve($slug);
 
         $q = (string) $request->query('q', '');
 

--- a/app/Http/Controllers/Api/Admin/LookupController.php
+++ b/app/Http/Controllers/Api/Admin/LookupController.php
@@ -33,6 +33,8 @@ class LookupController extends Controller
 
     public function departments(int $organizationId): JsonResponse
     {
+        abort_if(Organization::where('ID', $organizationId)->doesntExist(), 404);
+
         return response()->json([
             'data' => Department::query()
                 ->where('OrganizationID', $organizationId)

--- a/app/Http/Controllers/Api/Admin/RoutingRuleController.php
+++ b/app/Http/Controllers/Api/Admin/RoutingRuleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Admin\Concerns\ResolvesSamlClientBySlug;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\SamlClient;
@@ -14,6 +15,8 @@ use Illuminate\Http\Request;
 
 class RoutingRuleController extends Controller
 {
+    use ResolvesSamlClientBySlug;
+
     public function __construct(private SamlClientManager $manager) {}
 
     public function show(string $slug): JsonResponse
@@ -81,14 +84,5 @@ class RoutingRuleController extends Controller
                 'catch_all' => $rule->isCatchAll(),
             ])->values(),
         ];
-    }
-
-    private function resolve(string $slug): SamlClient
-    {
-        $client = SamlClient::where('slug', $slug)->first();
-
-        abort_if($client === null, 404);
-
-        return $client;
     }
 }

--- a/app/Http/Controllers/Api/Admin/RoutingRuleController.php
+++ b/app/Http/Controllers/Api/Admin/RoutingRuleController.php
@@ -30,6 +30,8 @@ class RoutingRuleController extends Controller
 
         $client = $this->manager->replaceRoutingRules($client, $orgRules, $departmentRules);
 
+        // Counts are trustworthy here: replaceRoutingRules is all-or-nothing —
+        // it throws on any validation failure before this line ever runs.
         AdminAudit::log($request, 'replace routing rules', [
             'slug' => $client->slug,
             'org_rule_count' => count($orgRules),

--- a/app/Http/Controllers/Api/Admin/RoutingRuleController.php
+++ b/app/Http/Controllers/Api/Admin/RoutingRuleController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Saml\SamlClientManager;
+use App\Support\AdminAudit;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RoutingRuleController extends Controller
+{
+    public function __construct(private SamlClientManager $manager) {}
+
+    public function show(string $slug): JsonResponse
+    {
+        return response()->json(['data' => $this->rules($this->resolve($slug))]);
+    }
+
+    public function replace(Request $request, string $slug): JsonResponse
+    {
+        $client = $this->resolve($slug);
+
+        $orgRules = $request->input('org_rules', []);
+        $departmentRules = $request->input('department_rules', []);
+
+        $client = $this->manager->replaceRoutingRules($client, $orgRules, $departmentRules);
+
+        AdminAudit::log($request, 'replace routing rules', [
+            'slug' => $client->slug,
+            'org_rule_count' => count($orgRules),
+            'department_rule_count' => count($departmentRules),
+            'org_rules' => $orgRules,
+            'department_rules' => $departmentRules,
+        ]);
+
+        return response()->json(['data' => $this->rules($client)]);
+    }
+
+    public function routableOrganizations(string $slug): JsonResponse
+    {
+        $client = $this->resolve($slug);
+
+        return response()->json([
+            'data' => Organization::whereIn('ID', $client->scopedOrganizationIds())
+                ->orderBy('Name')
+                ->get()
+                ->map(fn (Organization $org) => ['id' => $org->ID, 'name' => $org->Name])
+                ->values(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rules(SamlClient $client): array
+    {
+        $orgNames = Organization::whereIn('ID', $client->orgRules->pluck('organization_id')->unique())
+            ->pluck('Name', 'ID');
+
+        return [
+            'org_rules' => $client->orgRules->map(fn (SamlOrgRule $rule) => [
+                'attribute' => $rule->attribute,
+                'operator' => $rule->operator->value,
+                'value' => $rule->value,
+                'organization_id' => $rule->organization_id,
+                'organization_name' => $orgNames->get($rule->organization_id),
+                'catch_all' => $rule->isCatchAll(),
+            ])->values(),
+            'department_rules' => $client->departmentRules->map(fn (SamlDepartmentRule $rule) => [
+                'attribute' => $rule->attribute,
+                'operator' => $rule->operator->value,
+                'value' => $rule->value,
+                'department_name' => $rule->department_name,
+                'catch_all' => $rule->isCatchAll(),
+            ])->values(),
+        ];
+    }
+
+    private function resolve(string $slug): SamlClient
+    {
+        $client = SamlClient::where('slug', $slug)->first();
+
+        abort_if($client === null, 404);
+
+        return $client;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -176,6 +176,12 @@ class SamlClientController extends Controller
             'idp_sso_url' => $client->idp_sso_url,
             'attribute_map' => $client->attribute_map,
             'grants_count' => $client->grants()->count(),
+            'known_attributes' => $client->known_attributes,
+            'attribute_observations' => $client->attributeObservations()
+                ->orderByDesc('last_seen_at')
+                ->get()
+                ->map(fn ($o) => ['name' => $o->name, 'last_seen_at' => $o->last_seen_at?->toDateTimeString()])
+                ->all(),
         ];
     }
 }

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -6,7 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
 use App\Saml\SamlClientManager;
+use App\Support\AdminAudit;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
 
 class SamlClientController extends Controller
 {
@@ -24,6 +28,69 @@ class SamlClientController extends Controller
     public function show(string $slug): JsonResponse
     {
         return response()->json(['data' => $this->detail($this->resolve($slug))]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $client = $this->manager->create($request->all());
+
+        AdminAudit::log($request, 'create client', [
+            'slug' => $client->slug,
+            'fields' => array_keys($request->all()),
+            'email_domains' => $client->email_domains ?? [],
+        ]);
+
+        return response()->json(['data' => $this->detail($client)], 201);
+    }
+
+    public function update(Request $request, string $slug): JsonResponse
+    {
+        $client = $this->manager->update($this->resolve($slug), $request->all());
+
+        AdminAudit::log($request, 'update client', [
+            'slug' => $client->slug,
+            'fields' => array_keys($request->all()),
+            'email_domains' => $client->email_domains ?? [],
+        ]);
+
+        return response()->json(['data' => $this->detail($client)]);
+    }
+
+    public function idpMetadata(Request $request, string $slug): JsonResponse
+    {
+        $xml = (string) $request->input('xml', '');
+
+        try {
+            $client = $this->manager->updateFromIdpMetadata($this->resolve($slug), $xml);
+        } catch (InvalidArgumentException $e) {
+            throw ValidationException::withMessages(['xml' => $e->getMessage()]);
+        }
+
+        AdminAudit::log($request, 'idp metadata', ['slug' => $client->slug]);
+
+        return response()->json(['data' => $this->detail($client)]);
+    }
+
+    public function enable(Request $request, string $slug): JsonResponse
+    {
+        return $this->setEnabled($request, $slug, true);
+    }
+
+    public function disable(Request $request, string $slug): JsonResponse
+    {
+        return $this->setEnabled($request, $slug, false);
+    }
+
+    private function setEnabled(Request $request, string $slug, bool $enabled): JsonResponse
+    {
+        $client = $this->manager->setEnabled($this->resolve($slug), $enabled);
+
+        AdminAudit::log($request, $enabled ? 'enable client' : 'disable client', [
+            'slug' => $client->slug,
+            'enabled' => $enabled,
+        ]);
+
+        return response()->json(['data' => $this->detail($client)]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Admin\Concerns\ResolvesSamlClientBySlug;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\SamlClient;
-use App\Models\SsoGrant;
 use App\Models\System;
 use App\Saml\SamlClientManager;
 use App\Support\AdminAudit;
@@ -16,8 +16,7 @@ use InvalidArgumentException;
 
 class SamlClientController extends Controller
 {
-    /** Field names the manager's validators accept — the audit trail logs only these. */
-    private const EDITABLE_FIELDS = ['name', 'slug', 'owner_type', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
+    use ResolvesSamlClientBySlug;
 
     public function __construct(private SamlClientManager $manager) {}
 
@@ -26,7 +25,7 @@ class SamlClientController extends Controller
      */
     private function submittedEditableFields(Request $request): array
     {
-        return array_values(array_intersect(array_keys($request->all()), self::EDITABLE_FIELDS));
+        return array_values(array_intersect(array_keys($request->all()), SamlClientManager::EDITABLE_FIELDS));
     }
 
     public function index(): JsonResponse
@@ -62,16 +61,7 @@ class SamlClientController extends Controller
     {
         $client = $this->manager->create($request->all());
 
-        $context = [
-            'slug' => $client->slug,
-            'fields' => $this->submittedEditableFields($request),
-        ];
-
-        if (array_key_exists('email_domains', $request->all())) {
-            $context['email_domains'] = $client->email_domains ?? [];
-        }
-
-        AdminAudit::log($request, 'create client', $context);
+        AdminAudit::log($request, 'create client', $this->auditContext($request, $client));
 
         return response()->json(['data' => $this->detail($client)], 201);
     }
@@ -80,6 +70,16 @@ class SamlClientController extends Controller
     {
         $client = $this->manager->update($this->resolve($slug), $request->all());
 
+        AdminAudit::log($request, 'update client', $this->auditContext($request, $client));
+
+        return response()->json(['data' => $this->detail($client)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function auditContext(Request $request, SamlClient $client): array
+    {
         $context = [
             'slug' => $client->slug,
             'fields' => $this->submittedEditableFields($request),
@@ -89,9 +89,7 @@ class SamlClientController extends Controller
             $context['email_domains'] = $client->email_domains ?? [];
         }
 
-        AdminAudit::log($request, 'update client', $context);
-
-        return response()->json(['data' => $this->detail($client)]);
+        return $context;
     }
 
     public function idpMetadata(Request $request, string $slug): JsonResponse
@@ -177,16 +175,7 @@ class SamlClientController extends Controller
             'idp_entity_id' => $client->idp_entity_id,
             'idp_sso_url' => $client->idp_sso_url,
             'attribute_map' => $client->attribute_map,
-            'grants_count' => SsoGrant::where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id)->count(),
+            'grants_count' => $client->grants()->count(),
         ];
-    }
-
-    private function resolve(string $slug): SamlClient
-    {
-        $client = SamlClient::where('slug', $slug)->first();
-
-        abort_if($client === null, 404);
-
-        return $client;
     }
 }

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
 use App\Saml\SamlClientManager;
@@ -16,7 +15,7 @@ use InvalidArgumentException;
 class SamlClientController extends Controller
 {
     /** Field names the manager's validators accept — the audit trail logs only these. */
-    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
+    private const EDITABLE_FIELDS = ['name', 'slug', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
 
     public function __construct(private SamlClientManager $manager) {}
 
@@ -129,7 +128,7 @@ class SamlClientController extends Controller
             'enabled' => $client->enabled,
             'jit_enabled' => $client->jit_enabled,
             'admin_portal' => $client->admin_portal,
-            'organization_id' => $client->organization_id,
+            'organization_id' => $client->owner_id,
             'department_id' => $client->department_id,
             'email_domains' => $client->email_domains ?? [],
             'certificate' => [
@@ -150,8 +149,8 @@ class SamlClientController extends Controller
             'idp_entity_id' => $client->idp_entity_id,
             'idp_sso_url' => $client->idp_sso_url,
             'attribute_map' => $client->attribute_map,
-            'organization_name' => Organization::where('ID', $client->organization_id)->value('Name'),
-            'grants_count' => SsoGrant::where('organization_id', $client->organization_id)->count(),
+            'organization_name' => $client->ownerName(),
+            'grants_count' => SsoGrant::where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id)->count(),
         ];
     }
 

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
+use App\Models\System;
 use App\Saml\SamlClientManager;
 use App\Support\AdminAudit;
 use Illuminate\Http\JsonResponse;
@@ -29,9 +31,24 @@ class SamlClientController extends Controller
 
     public function index(): JsonResponse
     {
+        $clients = SamlClient::orderBy('name')->get();
+
+        $orgIds = $clients->where('owner_type', 'organization')->pluck('owner_id')->unique();
+        $systemIds = $clients->where('owner_type', 'system')->pluck('owner_id')->unique();
+
+        // Keyed "type:id" — organization and system IDs are independent spaces,
+        // so a plain ID-keyed map could collide the two.
+        $ownerNames = Organization::whereIn('ID', $orgIds)->pluck('Name', 'ID')
+            ->mapWithKeys(fn ($name, $id) => ["organization:{$id}" => $name])
+            ->union(
+                System::whereIn('ID', $systemIds)->pluck('Name', 'ID')
+                    ->mapWithKeys(fn ($name, $id) => ["system:{$id}" => $name])
+            )
+            ->all();
+
         return response()->json([
-            'data' => SamlClient::orderBy('name')->get()
-                ->map(fn (SamlClient $client) => $this->item($client))
+            'data' => $clients
+                ->map(fn (SamlClient $client) => $this->item($client, $ownerNames))
                 ->values(),
         ]);
     }
@@ -116,11 +133,17 @@ class SamlClientController extends Controller
     }
 
     /**
+     * @param  array<string, string>|null  $ownerNames  Preloaded "type:id" => name map (index());
+     *                                                  null falls back to a per-client lookup (detail()).
      * @return array<string, mixed>
      */
-    private function item(SamlClient $client): array
+    private function item(SamlClient $client, ?array $ownerNames = null): array
     {
         $cert = $this->manager->certificateStatus($client);
+
+        $ownerName = $ownerNames !== null
+            ? ($ownerNames["{$client->owner_type}:{$client->owner_id}"] ?? null)
+            : $client->ownerName();
 
         return [
             'name' => $client->name,
@@ -131,7 +154,7 @@ class SamlClientController extends Controller
             'owner' => [
                 'type' => $client->owner_type,
                 'id' => $client->owner_id,
-                'name' => $client->ownerName(),
+                'name' => $ownerName,
             ],
             'department_id' => $client->department_id,
             'email_domains' => $client->email_domains ?? [],
@@ -143,11 +166,12 @@ class SamlClientController extends Controller
     }
 
     /**
+     * @param  array<string, string>|null  $ownerNames  See item().
      * @return array<string, mixed>
      */
-    private function detail(SamlClient $client): array
+    private function detail(SamlClient $client, ?array $ownerNames = null): array
     {
-        return $this->item($client) + [
+        return $this->item($client, $ownerNames) + [
             'acs_url' => $client->acsUrl(),
             'metadata_url' => $client->metadataUrl(),
             'idp_entity_id' => $client->idp_entity_id,

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -14,7 +14,18 @@ use InvalidArgumentException;
 
 class SamlClientController extends Controller
 {
+    /** Field names the manager's validators accept — the audit trail logs only these. */
+    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'email_domains', 'attribute_map'];
+
     public function __construct(private SamlClientManager $manager) {}
+
+    /**
+     * @return array<int, string>
+     */
+    private function submittedEditableFields(Request $request): array
+    {
+        return array_values(array_intersect(array_keys($request->all()), self::EDITABLE_FIELDS));
+    }
 
     public function index(): JsonResponse
     {
@@ -34,11 +45,16 @@ class SamlClientController extends Controller
     {
         $client = $this->manager->create($request->all());
 
-        AdminAudit::log($request, 'create client', [
+        $context = [
             'slug' => $client->slug,
-            'fields' => array_keys($request->all()),
-            'email_domains' => $client->email_domains ?? [],
-        ]);
+            'fields' => $this->submittedEditableFields($request),
+        ];
+
+        if (array_key_exists('email_domains', $request->all())) {
+            $context['email_domains'] = $client->email_domains ?? [];
+        }
+
+        AdminAudit::log($request, 'create client', $context);
 
         return response()->json(['data' => $this->detail($client)], 201);
     }
@@ -47,11 +63,16 @@ class SamlClientController extends Controller
     {
         $client = $this->manager->update($this->resolve($slug), $request->all());
 
-        AdminAudit::log($request, 'update client', [
+        $context = [
             'slug' => $client->slug,
-            'fields' => array_keys($request->all()),
-            'email_domains' => $client->email_domains ?? [],
-        ]);
+            'fields' => $this->submittedEditableFields($request),
+        ];
+
+        if (array_key_exists('email_domains', $request->all())) {
+            $context['email_domains'] = $client->email_domains ?? [];
+        }
+
+        AdminAudit::log($request, 'update client', $context);
 
         return response()->json(['data' => $this->detail($client)]);
     }
@@ -66,6 +87,7 @@ class SamlClientController extends Controller
             throw ValidationException::withMessages(['xml' => $e->getMessage()]);
         }
 
+        // Metadata uploads only touch the fixed idp_* trio (entity_id, sso_url, certificate), so no fields context is logged.
         AdminAudit::log($request, 'idp metadata', ['slug' => $client->slug]);
 
         return response()->json(['data' => $this->detail($client)]);

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 class SamlClientController extends Controller
 {
     /** Field names the manager's validators accept — the audit trail logs only these. */
-    private const EDITABLE_FIELDS = ['name', 'slug', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
+    private const EDITABLE_FIELDS = ['name', 'slug', 'owner_type', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
 
     public function __construct(private SamlClientManager $manager) {}
 
@@ -128,7 +128,11 @@ class SamlClientController extends Controller
             'enabled' => $client->enabled,
             'jit_enabled' => $client->jit_enabled,
             'admin_portal' => $client->admin_portal,
-            'organization_id' => $client->owner_id,
+            'owner' => [
+                'type' => $client->owner_type,
+                'id' => $client->owner_id,
+                'name' => $client->ownerName(),
+            ],
             'department_id' => $client->department_id,
             'email_domains' => $client->email_domains ?? [],
             'certificate' => [
@@ -149,7 +153,6 @@ class SamlClientController extends Controller
             'idp_entity_id' => $client->idp_entity_id,
             'idp_sso_url' => $client->idp_sso_url,
             'attribute_map' => $client->attribute_map,
-            'organization_name' => $client->ownerName(),
             'grants_count' => SsoGrant::where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id)->count(),
         ];
     }

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
 use App\Saml\SamlClientManager;
@@ -148,6 +149,7 @@ class SamlClientController extends Controller
             'idp_entity_id' => $client->idp_entity_id,
             'idp_sso_url' => $client->idp_sso_url,
             'attribute_map' => $client->attribute_map,
+            'organization_name' => Organization::where('ID', $client->organization_id)->value('Name'),
             'grants_count' => SsoGrant::where('organization_id', $client->organization_id)->count(),
         ];
     }

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\SamlClient;
+use App\Models\SsoGrant;
+use App\Saml\SamlClientManager;
+use Illuminate\Http\JsonResponse;
+
+class SamlClientController extends Controller
+{
+    public function __construct(private SamlClientManager $manager) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'data' => SamlClient::orderBy('name')->get()
+                ->map(fn (SamlClient $client) => $this->item($client))
+                ->values(),
+        ]);
+    }
+
+    public function show(string $slug): JsonResponse
+    {
+        return response()->json(['data' => $this->detail($this->resolve($slug))]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function item(SamlClient $client): array
+    {
+        $cert = $this->manager->certificateStatus($client);
+
+        return [
+            'name' => $client->name,
+            'slug' => $client->slug,
+            'enabled' => $client->enabled,
+            'jit_enabled' => $client->jit_enabled,
+            'organization_id' => $client->organization_id,
+            'department_id' => $client->department_id,
+            'email_domains' => $client->email_domains ?? [],
+            'certificate' => [
+                'expires_at' => $cert['expires_at']?->toDateString(),
+                'expiring' => $cert['expiring'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function detail(SamlClient $client): array
+    {
+        return $this->item($client) + [
+            'acs_url' => $client->acsUrl(),
+            'metadata_url' => $client->metadataUrl(),
+            'idp_entity_id' => $client->idp_entity_id,
+            'idp_sso_url' => $client->idp_sso_url,
+            'attribute_map' => $client->attribute_map,
+            'grants_count' => SsoGrant::where('organization_id', $client->organization_id)->count(),
+        ];
+    }
+
+    private function resolve(string $slug): SamlClient
+    {
+        $client = SamlClient::where('slug', $slug)->first();
+
+        abort_if($client === null, 404);
+
+        return $client;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SamlClientController.php
+++ b/app/Http/Controllers/Api/Admin/SamlClientController.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 class SamlClientController extends Controller
 {
     /** Field names the manager's validators accept — the audit trail logs only these. */
-    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'email_domains', 'attribute_map'];
+    private const EDITABLE_FIELDS = ['name', 'slug', 'organization_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
 
     public function __construct(private SamlClientManager $manager) {}
 
@@ -128,6 +128,7 @@ class SamlClientController extends Controller
             'slug' => $client->slug,
             'enabled' => $client->enabled,
             'jit_enabled' => $client->jit_enabled,
+            'admin_portal' => $client->admin_portal,
             'organization_id' => $client->organization_id,
             'department_id' => $client->department_id,
             'email_domains' => $client->email_domains ?? [],

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Support\AdminAudit;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class SsoGrantController extends Controller
@@ -37,7 +38,7 @@ class SsoGrantController extends Controller
                 ]);
             }
 
-            if ($user->department?->OrganizationID !== $client->organization_id) {
+            if ($user->department === null || (int) $user->department->OrganizationID !== (int) $client->organization_id) {
                 throw ValidationException::withMessages([
                     'logins' => "{$login} does not belong to this client's organization.",
                 ]);
@@ -46,13 +47,15 @@ class SsoGrantController extends Controller
             return $user;
         });
 
-        SsoGrant::where('organization_id', $client->organization_id)->delete();
+        DB::transaction(function () use ($users, $client, $request) {
+            SsoGrant::where('organization_id', $client->organization_id)->delete();
 
-        $users->each(fn (User $user) => SsoGrant::create([
-            'user_id' => $user->ID,
-            'organization_id' => $client->organization_id,
-            'granted_by' => (string) $request->header('X-Acting-Admin'),
-        ]));
+            $users->each(fn (User $user) => SsoGrant::create([
+                'user_id' => $user->ID,
+                'organization_id' => $client->organization_id,
+                'granted_by' => (string) $request->header('X-Acting-Admin'),
+            ]));
+        });
 
         AdminAudit::log($request, 'replace grants', [
             'slug' => $client->slug,

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -38,7 +38,7 @@ class SsoGrantController extends Controller
                 ]);
             }
 
-            if ($user->department === null || (int) $user->department->OrganizationID !== (int) $client->organization_id) {
+            if ($user->department === null || (int) $user->department->OrganizationID !== (int) $client->owner_id) {
                 throw ValidationException::withMessages([
                     'logins' => "{$login} does not belong to this client's organization.",
                 ]);
@@ -48,11 +48,12 @@ class SsoGrantController extends Controller
         });
 
         DB::transaction(function () use ($users, $client, $request) {
-            SsoGrant::where('organization_id', $client->organization_id)->delete();
+            SsoGrant::where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id)->delete();
 
             $users->each(fn (User $user) => SsoGrant::create([
                 'user_id' => $user->ID,
-                'organization_id' => $client->organization_id,
+                'owner_type' => $client->owner_type,
+                'owner_id' => $client->owner_id,
                 'granted_by' => (string) $request->header('X-Acting-Admin'),
             ]));
         });
@@ -72,7 +73,8 @@ class SsoGrantController extends Controller
     private function grantsFor(SamlClient $client): array
     {
         return SsoGrant::with('user')
-            ->where('organization_id', $client->organization_id)
+            ->where('owner_type', $client->owner_type)
+            ->where('owner_id', $client->owner_id)
             ->orderBy('created_at')
             ->get()
             ->map(fn (SsoGrant $grant) => [

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Admin\Concerns\ResolvesSamlClientBySlug;
 use App\Http\Controllers\Controller;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
@@ -14,6 +15,8 @@ use Illuminate\Validation\ValidationException;
 
 class SsoGrantController extends Controller
 {
+    use ResolvesSamlClientBySlug;
+
     public function index(string $slug): JsonResponse
     {
         return response()->json(['data' => $this->grantsFor($this->resolve($slug))]);
@@ -52,7 +55,7 @@ class SsoGrantController extends Controller
         });
 
         DB::transaction(function () use ($users, $client, $request) {
-            SsoGrant::where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id)->delete();
+            $client->grants()->delete();
 
             $users->each(fn (User $user) => SsoGrant::create([
                 'user_id' => $user->ID,
@@ -76,10 +79,7 @@ class SsoGrantController extends Controller
      */
     private function grantsFor(SamlClient $client): array
     {
-        return SsoGrant::with('user')
-            ->where('owner_type', $client->owner_type)
-            ->where('owner_id', $client->owner_id)
-            ->orderBy('created_at')
+        return $client->grants()->with('user')->orderBy('created_at')
             ->get()
             ->map(fn (SsoGrant $grant) => [
                 'login' => $grant->user?->Login,
@@ -88,14 +88,5 @@ class SsoGrantController extends Controller
                 'granted_by' => $grant->granted_by,
                 'created_at' => $grant->created_at?->toDateTimeString(),
             ])->values()->all();
-    }
-
-    private function resolve(string $slug): SamlClient
-    {
-        $client = SamlClient::where('slug', $slug)->first();
-
-        abort_if($client === null, 404);
-
-        return $client;
     }
 }

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -31,8 +31,10 @@ class SsoGrantController extends Controller
 
         $scope = $client->scopedOrganizationIds();
 
-        $users = collect($logins)->map(function (string $login) use ($scope) {
-            $user = User::with('department')->where('Login', $login)->first();
+        $usersByLogin = User::with('department')->whereIn('Login', $logins)->get()->keyBy('Login');
+
+        $users = collect($logins)->map(function (string $login) use ($scope, $usersByLogin) {
+            $user = $usersByLogin->get($login);
 
             if (! $user) {
                 throw ValidationException::withMessages([

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -60,6 +60,7 @@ class SsoGrantController extends Controller
         AdminAudit::log($request, 'replace grants', [
             'slug' => $client->slug,
             'grant_count' => $users->count(),
+            'logins' => $users->pluck('Login')->values()->all(),
         ]);
 
         return response()->json(['data' => $this->grantsFor($client)]);

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\SamlClient;
+use App\Models\SsoGrant;
+use App\Models\User;
+use App\Support\AdminAudit;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class SsoGrantController extends Controller
+{
+    public function index(string $slug): JsonResponse
+    {
+        return response()->json(['data' => $this->grantsFor($this->resolve($slug))]);
+    }
+
+    /**
+     * Replace semantics, mirroring `saml:client update --domains`:
+     * the submitted list IS the grant list afterward.
+     */
+    public function replace(Request $request, string $slug): JsonResponse
+    {
+        $client = $this->resolve($slug);
+
+        $logins = $request->validate(['logins' => ['present', 'array'], 'logins.*' => ['string']])['logins'];
+
+        $users = collect($logins)->map(function (string $login) use ($client) {
+            $user = User::with('department')->where('Login', $login)->first();
+
+            if (! $user) {
+                throw ValidationException::withMessages([
+                    'logins' => "No user found for {$login}.",
+                ]);
+            }
+
+            if ($user->department?->OrganizationID !== $client->organization_id) {
+                throw ValidationException::withMessages([
+                    'logins' => "{$login} does not belong to this client's organization.",
+                ]);
+            }
+
+            return $user;
+        });
+
+        SsoGrant::where('organization_id', $client->organization_id)->delete();
+
+        $users->each(fn (User $user) => SsoGrant::create([
+            'user_id' => $user->ID,
+            'organization_id' => $client->organization_id,
+            'granted_by' => (string) $request->header('X-Acting-Admin'),
+        ]));
+
+        AdminAudit::log($request, 'replace grants', [
+            'slug' => $client->slug,
+            'grant_count' => $users->count(),
+        ]);
+
+        return response()->json(['data' => $this->grantsFor($client)]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function grantsFor(SamlClient $client): array
+    {
+        return SsoGrant::with('user')
+            ->where('organization_id', $client->organization_id)
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn (SsoGrant $grant) => [
+                'login' => $grant->user?->Login,
+                'first_name' => $grant->user?->FirstName,
+                'last_name' => $grant->user?->LastName,
+                'granted_by' => $grant->granted_by,
+                'created_at' => $grant->created_at?->toDateTimeString(),
+            ])->values()->all();
+    }
+
+    private function resolve(string $slug): SamlClient
+    {
+        $client = SamlClient::where('slug', $slug)->first();
+
+        abort_if($client === null, 404);
+
+        return $client;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SsoGrantController.php
+++ b/app/Http/Controllers/Api/Admin/SsoGrantController.php
@@ -29,7 +29,9 @@ class SsoGrantController extends Controller
 
         $logins = $request->validate(['logins' => ['present', 'array'], 'logins.*' => ['string']])['logins'];
 
-        $users = collect($logins)->map(function (string $login) use ($client) {
+        $scope = $client->scopedOrganizationIds();
+
+        $users = collect($logins)->map(function (string $login) use ($scope) {
             $user = User::with('department')->where('Login', $login)->first();
 
             if (! $user) {
@@ -38,9 +40,9 @@ class SsoGrantController extends Controller
                 ]);
             }
 
-            if ($user->department === null || (int) $user->department->OrganizationID !== (int) $client->owner_id) {
+            if ($user->department === null || ! in_array((int) $user->department->OrganizationID, $scope, true)) {
                 throw ValidationException::withMessages([
-                    'logins' => "{$login} does not belong to this client's organization.",
+                    'logins' => "{$login} does not belong to this client's scope.",
                 ]);
             }
 

--- a/app/Http/Controllers/Api/Admin/SsoHandoffController.php
+++ b/app/Http/Controllers/Api/Admin/SsoHandoffController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SsoHandoffController extends Controller
+{
+    /**
+     * Exchange a single-use admin SSO token for the Employee identity.
+     * Called server-to-server by website_admin/ssoLogon.php; the token
+     * arriving in a browser URL is worthless without the bearer token.
+     */
+    public function redeem(Request $request, AdminSsoHandoff $handoff): JsonResponse
+    {
+        $payload = $handoff->redeem((string) $request->input('token', ''));
+
+        abort_if($payload === null, 404);
+
+        return response()->json(['data' => $payload]);
+    }
+}

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\SamlClient;
 use App\Models\User;
 use App\Saml\AdminSsoHandoff;
+use App\Saml\AttributeRouter;
 use App\Saml\SamlClientManager;
 use App\Saml\SamlLoginRejected;
 use App\Saml\SamlSettingsFactory;
@@ -23,6 +24,7 @@ class SamlController extends Controller
         private SamlSettingsFactory $settings,
         private SamlUserProvisioner $provisioner,
         private AdminSsoHandoff $adminHandoff,
+        private AttributeRouter $router,
     ) {}
 
     public function acs(Request $request, string $slug)
@@ -69,6 +71,9 @@ class SamlController extends Controller
 
         // Spec: warn while assertions still validate but the IdP cert nears expiry
         $certStatus = app(SamlClientManager::class)->certificateStatus($client);
+        // Deliberately a separate read from the provisioner's own lookup: routing needs the fallback org before the disabled/JIT guards run.
+        $existing = User::where('Login', $email)->first();
+        $placement = $this->router->route($client, $auth->getAttributes(), $existing?->department?->OrganizationID);
         if ($certStatus['expiring']) {
             Log::warning('SAML client IdP certificate expires soon', [
                 'client' => $client->slug,
@@ -90,12 +95,12 @@ class SamlController extends Controller
         }
 
         try {
-            $user = $this->provisioner->provision($client, $email, $firstName, $lastName);
+            $user = $this->provisioner->provision($client, $email, $firstName, $lastName, $placement);
         } catch (SamlLoginRejected $e) {
             return $this->reject($client, $e->logContext, $e->publicMessage);
         }
 
-        $this->establishSession($request, $user, $client);
+        $this->establishSession($request, $user, $client, $placement);
 
         if ($user->DepartmentID == null || $user->CredentialID == null) { // loose: matches 0
             return redirect('/finishAccountCreation');
@@ -175,7 +180,10 @@ class SamlController extends Controller
         ];
     }
 
-    private function establishSession(Request $request, User $user, SamlClient $client): void
+    /**
+     * @param  array{organization_id: int, department_id: ?int}|null  $placement
+     */
+    private function establishSession(Request $request, User $user, SamlClient $client, ?array $placement = null): void
     {
         Auth::login($user);
         $request->session()->regenerate();
@@ -193,9 +201,12 @@ class SamlController extends Controller
         // org. Edge: an existing dept-less user (DepartmentID 0) on a
         // system-owned client gets null here — FinishUserCreation renders an
         // empty department list until routing (milestone 5) places them.
-        $request->session()->put('Organization', $client->ownedByOrganization()
+        // A routed placement always wins: it's the freshest read of "which org
+        // this login belongs to," overriding both the static owner and the
+        // user's previously stored department.
+        $request->session()->put('Organization', $placement['organization_id'] ?? ($client->ownedByOrganization()
             ? $client->owner_id
-            : $user->department?->OrganizationID);
+            : $user->department?->OrganizationID));
         // dashboard route uses a plain 302 for SAML sessions (IdPs can't follow Inertia 409s)
         $request->session()->put('SAML', true);
 

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -74,7 +74,7 @@ class SamlController extends Controller
         // Record which attribute names this IdP asserts, for the routing rule
         // editor. Names only; the collector skips admin-portal clients and can
         // never break a login (spec: known attributes).
-        $this->attributeCollector->capture($client, $auth->getAttributes());
+        $this->attributeCollector->capture($client, array_keys($auth->getAttributes()));
 
         // Spec: warn while assertions still validate but the IdP cert nears expiry
         $certStatus = app(SamlClientManager::class)->certificateStatus($client);

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\SamlClient;
 use App\Models\User;
+use App\Saml\AdminSsoHandoff;
 use App\Saml\SamlClientManager;
 use App\Saml\SamlLoginRejected;
 use App\Saml\SamlSettingsFactory;
@@ -21,6 +22,7 @@ class SamlController extends Controller
     public function __construct(
         private SamlSettingsFactory $settings,
         private SamlUserProvisioner $provisioner,
+        private AdminSsoHandoff $adminHandoff,
     ) {}
 
     public function acs(Request $request, string $slug)
@@ -63,6 +65,19 @@ class SamlController extends Controller
 
         if ($email === null) {
             return $this->reject($client, ['reason' => 'no_email_attribute']);
+        }
+
+        // Admin-portal clients assert Employee identities: no JIT, no Users
+        // lookup, no Laravel session — hand off to the portal's own session
+        // world via a single-use token (spec: admin portal SSO).
+        if ($client->admin_portal) {
+            try {
+                $redirect = $this->adminHandoff->initiate($client, $email);
+            } catch (SamlLoginRejected $e) {
+                return $this->reject($client, $e->logContext, $e->publicMessage);
+            }
+
+            return redirect()->away($redirect);
         }
 
         try {

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -67,6 +67,15 @@ class SamlController extends Controller
             return $this->reject($client, ['reason' => 'no_email_attribute']);
         }
 
+        // Spec: warn while assertions still validate but the IdP cert nears expiry
+        $certStatus = app(SamlClientManager::class)->certificateStatus($client);
+        if ($certStatus['expiring']) {
+            Log::warning('SAML client IdP certificate expires soon', [
+                'client' => $client->slug,
+                'expires_at' => $certStatus['expires_at']?->toDateString(),
+            ]);
+        }
+
         // Admin-portal clients assert Employee identities: no JIT, no Users
         // lookup, no Laravel session — hand off to the portal's own session
         // world via a single-use token (spec: admin portal SSO).
@@ -84,15 +93,6 @@ class SamlController extends Controller
             $user = $this->provisioner->provision($client, $email, $firstName, $lastName);
         } catch (SamlLoginRejected $e) {
             return $this->reject($client, $e->logContext, $e->publicMessage);
-        }
-
-        // Spec: warn while assertions still validate but the IdP cert nears expiry
-        $certStatus = app(SamlClientManager::class)->certificateStatus($client);
-        if ($certStatus['expiring']) {
-            Log::warning('SAML client IdP certificate expires soon', [
-                'client' => $client->slug,
-                'expires_at' => $certStatus['expires_at']?->toDateString(),
-            ]);
         }
 
         $this->establishSession($request, $user, $client);

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -71,9 +71,6 @@ class SamlController extends Controller
 
         // Spec: warn while assertions still validate but the IdP cert nears expiry
         $certStatus = app(SamlClientManager::class)->certificateStatus($client);
-        // Deliberately a separate read from the provisioner's own lookup: routing needs the fallback org before the disabled/JIT guards run.
-        $existing = User::where('Login', $email)->first();
-        $placement = $this->router->route($client, $auth->getAttributes(), $existing?->department?->OrganizationID);
         if ($certStatus['expiring']) {
             Log::warning('SAML client IdP certificate expires soon', [
                 'client' => $client->slug,
@@ -94,13 +91,17 @@ class SamlController extends Controller
             return redirect()->away($redirect);
         }
 
+        // Deliberately a separate read from the provisioner's own lookup: routing needs the fallback org before the disabled/JIT guards run.
+        $existing = User::where('Login', $email)->first();
+        $placement = $this->router->route($client, $auth->getAttributes(), $existing?->department?->OrganizationID);
+
         try {
             $user = $this->provisioner->provision($client, $email, $firstName, $lastName, $placement);
         } catch (SamlLoginRejected $e) {
             return $this->reject($client, $e->logContext, $e->publicMessage);
         }
 
-        $this->establishSession($request, $user, $client, $placement);
+        $this->establishSession($request, $user, $client, $placement, $existing === null);
 
         if ($user->DepartmentID == null || $user->CredentialID == null) { // loose: matches 0
             return redirect('/finishAccountCreation');
@@ -183,7 +184,7 @@ class SamlController extends Controller
     /**
      * @param  array{organization_id: int, department_id: ?int}|null  $placement
      */
-    private function establishSession(Request $request, User $user, SamlClient $client, ?array $placement = null): void
+    private function establishSession(Request $request, User $user, SamlClient $client, ?array $placement = null, bool $wasJitCreated = false): void
     {
         Auth::login($user);
         $request->session()->regenerate();
@@ -201,12 +202,16 @@ class SamlController extends Controller
         // org. Edge: an existing dept-less user (DepartmentID 0) on a
         // system-owned client gets null here — FinishUserCreation renders an
         // empty department list until routing (milestone 5) places them.
-        // A routed placement always wins: it's the freshest read of "which org
-        // this login belongs to," overriding both the static owner and the
-        // user's previously stored department.
-        $request->session()->put('Organization', $placement['organization_id'] ?? ($client->ownedByOrganization()
-            ? $client->owner_id
-            : $user->department?->OrganizationID));
+        // A placement's org only wins when it was actually applied to this
+        // user: a resolved department (provisioner moved/placed them there)
+        // or a fresh JIT creation (the placement is the only org they've
+        // ever had). An existing user whose department rule didn't resolve
+        // was left untouched by the provisioner, so the session should
+        // reflect their real (unmoved) department's org, not the routed one.
+        $placementApplied = $placement !== null && ($placement['department_id'] !== null || $wasJitCreated);
+        $request->session()->put('Organization', $placementApplied
+            ? $placement['organization_id']
+            : ($client->ownedByOrganization() ? $client->owner_id : $user->department?->OrganizationID));
         // dashboard route uses a plain 302 for SAML sessions (IdPs can't follow Inertia 409s)
         $request->session()->put('SAML', true);
 

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -188,8 +188,12 @@ class SamlController extends Controller
         $request->session()->put('userID', $user->ID);
         $request->session()->put('userName', $user->FirstName.' '.$user->LastName);
         $request->session()->put('Username', $user->FirstName.' '.$user->LastName);
-        // finishAccountCreation lists departments from this key
-        $request->session()->put('Organization', $client->owner_id);
+        // finishAccountCreation lists departments from this key. Org-owned
+        // clients offer their org; system-owned users carry their own org
+        // (new system-client users were rejected upstream until routing).
+        $request->session()->put('Organization', $client->ownedByOrganization()
+            ? $client->owner_id
+            : $user->department?->OrganizationID);
         // dashboard route uses a plain 302 for SAML sessions (IdPs can't follow Inertia 409s)
         $request->session()->put('SAML', true);
 

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -189,7 +189,7 @@ class SamlController extends Controller
         $request->session()->put('userName', $user->FirstName.' '.$user->LastName);
         $request->session()->put('Username', $user->FirstName.' '.$user->LastName);
         // finishAccountCreation lists departments from this key
-        $request->session()->put('Organization', $client->organization_id);
+        $request->session()->put('Organization', $client->owner_id);
         // dashboard route uses a plain 302 for SAML sessions (IdPs can't follow Inertia 409s)
         $request->session()->put('SAML', true);
 

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -7,6 +7,7 @@ use App\Models\SamlClient;
 use App\Models\User;
 use App\Saml\AdminSsoHandoff;
 use App\Saml\AttributeRouter;
+use App\Saml\KnownAttributeCollector;
 use App\Saml\SamlClientManager;
 use App\Saml\SamlLoginRejected;
 use App\Saml\SamlSettingsFactory;
@@ -25,6 +26,7 @@ class SamlController extends Controller
         private SamlUserProvisioner $provisioner,
         private AdminSsoHandoff $adminHandoff,
         private AttributeRouter $router,
+        private KnownAttributeCollector $attributeCollector,
     ) {}
 
     public function acs(Request $request, string $slug)
@@ -68,6 +70,11 @@ class SamlController extends Controller
         if ($email === null) {
             return $this->reject($client, ['reason' => 'no_email_attribute']);
         }
+
+        // Record which attribute names this IdP asserts, for the routing rule
+        // editor. Names only; the collector skips admin-portal clients and can
+        // never break a login (spec: known attributes).
+        $this->attributeCollector->capture($client, $auth->getAttributes());
 
         // Spec: warn while assertions still validate but the IdP cert nears expiry
         $certStatus = app(SamlClientManager::class)->certificateStatus($client);

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -189,8 +189,10 @@ class SamlController extends Controller
         $request->session()->put('userName', $user->FirstName.' '.$user->LastName);
         $request->session()->put('Username', $user->FirstName.' '.$user->LastName);
         // finishAccountCreation lists departments from this key. Org-owned
-        // clients offer their org; system-owned users carry their own org
-        // (new system-client users were rejected upstream until routing).
+        // clients offer their org; system-owned users carry their department's
+        // org. Edge: an existing dept-less user (DepartmentID 0) on a
+        // system-owned client gets null here — FinishUserCreation renders an
+        // empty department list until routing (milestone 5) places them.
         $request->session()->put('Organization', $client->ownedByOrganization()
             ? $client->owner_id
             : $user->department?->OrganizationID);

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -96,7 +96,7 @@ class SamlController extends Controller
         $placement = $this->router->route($client, $auth->getAttributes(), $existing?->department?->OrganizationID);
 
         try {
-            $user = $this->provisioner->provision($client, $email, $firstName, $lastName, $placement);
+            $user = $this->provisioner->provision($client, $email, $firstName, $lastName, $placement, $existing);
         } catch (SamlLoginRejected $e) {
             return $this->reject($client, $e->logContext, $e->publicMessage);
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\AdminApiToken;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\HandleInertiaRequests;
@@ -77,6 +78,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
+        'admin.api' => AdminApiToken::class,
         'auth' => Authenticate::class,
         'auth.basic' => AuthenticateWithBasicAuth::class,
         'cache.headers' => SetCacheHeaders::class,

--- a/app/Http/Middleware/AdminApiToken.php
+++ b/app/Http/Middleware/AdminApiToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminApiToken
+{
+    /**
+     * The token authorizes; X-Acting-Admin only attributes (audit).
+     * Missing configuration fails closed.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $expected = config('admin.api_token');
+
+        if (empty($expected)) {
+            Log::error('ADMIN_API_TOKEN is not configured; admin API request refused');
+
+            return response()->json(['message' => 'Admin API is not configured.'], 503);
+        }
+
+        if (! hash_equals((string) $expected, (string) $request->bearerToken())) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        $isMutation = in_array($request->method(), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
+
+        if ($isMutation && trim((string) $request->header('X-Acting-Admin', '')) === '') {
+            return response()->json(['message' => 'X-Acting-Admin header is required.'], 400);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Concerns/HasCatchAllTriple.php
+++ b/app/Models/Concerns/HasCatchAllTriple.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Saml\RoutingOperator;
+
+trait HasCatchAllTriple
+{
+    /** The reserved * / wildcard / * triple: matches every login. */
+    public function isCatchAll(): bool
+    {
+        return $this->attribute === '*'
+            && $this->operator === RoutingOperator::Wildcard
+            && $this->value === '*';
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+/**
+ * Apex staff — the admin portal's auth table (website_admin/doLogon.php).
+ * Read-only from this app's perspective: SSO matches rows, never writes them.
+ */
+class Employee extends LegacyModel
+{
+    protected $table = 'Employees';
+
+    public $timestamps = false;
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -3,8 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
 class Organization extends LegacyModel
 {
@@ -21,15 +21,15 @@ class Organization extends LegacyModel
         return $this->hasMany(Department::class, 'OrganizationID', 'ID');
     }
 
-    public function systems(): BelongsToMany
+    public function system(): HasOneThrough
     {
-        return $this->belongsToMany(
+        return $this->hasOneThrough(
             System::class,
-            'SystemOrganizations',
-            'OrganizationID',
+            SystemOrganization::class,
+            'OrganizationID', // FK on SystemOrganizations → Organizations.ID
+            'ID',             // key on Systems matched to SystemOrganizations.SystemID
+            'ID',             // local key on Organizations
             'SystemID',
-            'ID',
-            'ID',
         );
     }
 }

--- a/app/Models/SamlAttributeObservation.php
+++ b/app/Models/SamlAttributeObservation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SamlAttributeObservation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['saml_client_id', 'name', 'first_seen_at', 'last_seen_at', 'observation_count'];
+
+    protected $casts = [
+        'first_seen_at' => 'datetime',
+        'last_seen_at' => 'datetime',
+        'observation_count' => 'integer',
+    ];
+}

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -19,6 +19,7 @@ class SamlClient extends Model
         'organization_id',
         'department_id',
         'jit_enabled',
+        'admin_portal',
         'attribute_map',
         'email_domains',
     ];
@@ -26,6 +27,7 @@ class SamlClient extends Model
     protected $casts = [
         'enabled' => 'boolean',
         'jit_enabled' => 'boolean',
+        'admin_portal' => 'boolean',
         'attribute_map' => 'array',
         'email_domains' => 'array',
     ];
@@ -47,6 +49,7 @@ class SamlClient extends Model
     public static function forEmailDomain(string $domain): ?self
     {
         return static::where('enabled', true)
+            ->where('admin_portal', false)
             ->whereJsonContains('email_domains', strtolower($domain))
             ->first();
     }

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -26,6 +26,7 @@ class SamlClient extends Model
         'admin_portal',
         'attribute_map',
         'email_domains',
+        'known_attributes',
     ];
 
     protected $casts = [
@@ -100,6 +101,30 @@ class SamlClient extends Model
     public function departmentRules(): HasMany
     {
         return $this->hasMany(SamlDepartmentRule::class)->orderBy('position');
+    }
+
+    public function attributeObservations(): HasMany
+    {
+        return $this->hasMany(SamlAttributeObservation::class);
+    }
+
+    /**
+     * A null json column casts to null, not []; normalize so consumers can
+     * always iterate. (The array cast alone returns null for a null column
+     * in Laravel 12.)
+     */
+    public function getKnownAttributesAttribute($value): array
+    {
+        return $value === null ? [] : (array) json_decode($value, true);
+    }
+
+    /**
+     * Ensure arrays serialize to json on save, mirroring what the removed
+     * array cast did on write, so read+write conversion is explicit and paired.
+     */
+    public function setKnownAttributesAttribute($value): void
+    {
+        $this->attributes['known_attributes'] = json_encode(array_values((array) $value));
     }
 
     /**

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -99,5 +100,19 @@ class SamlClient extends Model
     public function departmentRules(): HasMany
     {
         return $this->hasMany(SamlDepartmentRule::class)->orderBy('position');
+    }
+
+    /**
+     * SsoGrant rows for this client's owner tuple. Not a real Eloquent
+     * relation: SsoGrant.owner_id references SamlClient.owner_id (the
+     * polymorphic-by-hand owner tuple), not SamlClient.id, so a plain
+     * hasMany('owner_id') would silently join on the wrong column. See
+     * SsoGrant::scopeForOwner().
+     *
+     * @return Builder<SsoGrant>
+     */
+    public function grants(): Builder
+    {
+        return SsoGrant::forOwner($this);
     }
 }

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 
 class SamlClient extends Model
@@ -88,5 +89,15 @@ class SamlClient extends Model
             ->where('admin_portal', false)
             ->whereJsonContains('email_domains', strtolower($domain))
             ->first();
+    }
+
+    public function orgRules(): HasMany
+    {
+        return $this->hasMany(SamlOrgRule::class)->orderBy('position');
+    }
+
+    public function departmentRules(): HasMany
+    {
+        return $this->hasMany(SamlDepartmentRule::class)->orderBy('position');
     }
 }

--- a/app/Models/SamlClient.php
+++ b/app/Models/SamlClient.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class SamlClient extends Model
 {
@@ -16,7 +17,8 @@ class SamlClient extends Model
         'idp_entity_id',
         'idp_sso_url',
         'idp_certificate',
-        'organization_id',
+        'owner_type',
+        'owner_id',
         'department_id',
         'jit_enabled',
         'admin_portal',
@@ -30,6 +32,7 @@ class SamlClient extends Model
         'admin_portal' => 'boolean',
         'attribute_map' => 'array',
         'email_domains' => 'array',
+        'owner_id' => 'integer',
     ];
 
     public function acsUrl(): string
@@ -40,6 +43,39 @@ class SamlClient extends Model
     public function metadataUrl(): string
     {
         return url("/saml/{$this->slug}/metadata");
+    }
+
+    public function ownedByOrganization(): bool
+    {
+        return $this->owner_type === 'organization';
+    }
+
+    public function ownerName(): ?string
+    {
+        return $this->ownedByOrganization()
+            ? Organization::where('ID', $this->owner_id)->value('Name')
+            : System::where('ID', $this->owner_id)->value('Name');
+    }
+
+    /**
+     * The organizations this client may place or grant users in: the owning
+     * org, or every org of the owning system. An organization belongs to one
+     * system by business rule; SystemOrganizations doesn't enforce it, so
+     * select tolerantly.
+     *
+     * @return array<int, int>
+     */
+    public function scopedOrganizationIds(): array
+    {
+        if ($this->ownedByOrganization()) {
+            return [$this->owner_id];
+        }
+
+        return DB::table('SystemOrganizations')
+            ->where('SystemID', $this->owner_id)
+            ->pluck('OrganizationID')
+            ->map(fn ($id) => (int) $id)
+            ->all();
     }
 
     /**

--- a/app/Models/SamlDepartmentRule.php
+++ b/app/Models/SamlDepartmentRule.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use App\Saml\RoutingOperator;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SamlDepartmentRule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['saml_client_id', 'position', 'attribute', 'operator', 'value', 'department_name'];
+
+    protected $casts = [
+        'position' => 'integer',
+        'operator' => RoutingOperator::class,
+    ];
+
+    /** The reserved * / wildcard / * triple: matches every login. */
+    public function isCatchAll(): bool
+    {
+        return $this->attribute === '*'
+            && $this->operator === RoutingOperator::Wildcard
+            && $this->value === '*';
+    }
+}

--- a/app/Models/SamlDepartmentRule.php
+++ b/app/Models/SamlDepartmentRule.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasCatchAllTriple;
 use App\Saml\RoutingOperator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class SamlDepartmentRule extends Model
 {
+    use HasCatchAllTriple;
     use HasFactory;
 
     protected $fillable = ['saml_client_id', 'position', 'attribute', 'operator', 'value', 'department_name'];
@@ -16,12 +18,4 @@ class SamlDepartmentRule extends Model
         'position' => 'integer',
         'operator' => RoutingOperator::class,
     ];
-
-    /** The reserved * / wildcard / * triple: matches every login. */
-    public function isCatchAll(): bool
-    {
-        return $this->attribute === '*'
-            && $this->operator === RoutingOperator::Wildcard
-            && $this->value === '*';
-    }
 }

--- a/app/Models/SamlOrgRule.php
+++ b/app/Models/SamlOrgRule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use App\Saml\RoutingOperator;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SamlOrgRule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['saml_client_id', 'position', 'attribute', 'operator', 'value', 'organization_id'];
+
+    protected $casts = [
+        'position' => 'integer',
+        'organization_id' => 'integer',
+        'operator' => RoutingOperator::class,
+    ];
+
+    /** The reserved * / wildcard / * triple: matches every login. */
+    public function isCatchAll(): bool
+    {
+        return $this->attribute === '*'
+            && $this->operator === RoutingOperator::Wildcard
+            && $this->value === '*';
+    }
+}

--- a/app/Models/SamlOrgRule.php
+++ b/app/Models/SamlOrgRule.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasCatchAllTriple;
 use App\Saml\RoutingOperator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class SamlOrgRule extends Model
 {
+    use HasCatchAllTriple;
     use HasFactory;
 
     protected $fillable = ['saml_client_id', 'position', 'attribute', 'operator', 'value', 'organization_id'];
@@ -17,12 +19,4 @@ class SamlOrgRule extends Model
         'organization_id' => 'integer',
         'operator' => RoutingOperator::class,
     ];
-
-    /** The reserved * / wildcard / * triple: matches every login. */
-    public function isCatchAll(): bool
-    {
-        return $this->attribute === '*'
-            && $this->operator === RoutingOperator::Wildcard
-            && $this->value === '*';
-    }
 }

--- a/app/Models/SsoGrant.php
+++ b/app/Models/SsoGrant.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,5 +16,19 @@ class SsoGrant extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id', 'ID');
+    }
+
+    /**
+     * Grants belonging to a SamlClient's owner tuple (owner_type + owner_id).
+     * A plain hasMany on SamlClient would join on SamlClient.id, which is
+     * not what SsoGrant.owner_id references — this scope is the correct
+     * "relation" between the two.
+     *
+     * @param  Builder<SsoGrant>  $query
+     * @return Builder<SsoGrant>
+     */
+    public function scopeForOwner(Builder $query, SamlClient $client): Builder
+    {
+        return $query->where('owner_type', $client->owner_type)->where('owner_id', $client->owner_id);
     }
 }

--- a/app/Models/SsoGrant.php
+++ b/app/Models/SsoGrant.php
@@ -10,7 +10,7 @@ class SsoGrant extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'organization_id', 'granted_by'];
+    protected $fillable = ['user_id', 'owner_type', 'owner_id', 'granted_by'];
 
     public function user(): BelongsTo
     {

--- a/app/Models/SsoGrant.php
+++ b/app/Models/SsoGrant.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SsoGrant extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'organization_id', 'granted_by'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'ID');
+    }
+}

--- a/app/Models/System.php
+++ b/app/Models/System.php
@@ -24,6 +24,6 @@ class System extends LegacyModel
             'OrganizationID',
             'ID',
             'ID',
-        );
+        )->using(SystemOrganization::class);
     }
 }

--- a/app/Models/SystemOrganization.php
+++ b/app/Models/SystemOrganization.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Join row between Systems and Organizations. The table allows many systems
+ * per org, but the business rule is one: write through updateOrCreate keyed
+ * on OrganizationID (see OrganizationFactory::forSystem()).
+ */
+class SystemOrganization extends Pivot
+{
+    public $timestamps = false;
+
+    public $incrementing = true;
+
+    protected $table = 'SystemOrganizations';
+
+    protected $primaryKey = 'ID';
+
+    protected $fillable = ['SystemID', 'OrganizationID'];
+}

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -37,7 +37,7 @@ class AdminSsoHandoff
             (int) config('saml.admin_handoff_ttl'),
         );
 
-        Log::info('SAML admin portal login', [
+        Log::info('Admin portal SSO handoff initiated', [
             'client' => $client->slug,
             'employee_id' => $employee->ID,
         ]);
@@ -56,9 +56,17 @@ class AdminSsoHandoff
         $store = Cache::store(config('saml.replay_store'));
 
         if (! $store->add(self::KEY_PREFIX.'claim:'.$token, 1, (int) config('saml.admin_handoff_ttl'))) {
+            Log::warning('Admin SSO handoff redemption failed', ['already_claimed' => true]);
+
             return null;
         }
 
-        return $store->pull(self::KEY_PREFIX.$token);
+        $payload = $store->pull(self::KEY_PREFIX.$token);
+
+        if ($payload === null) {
+            Log::warning('Admin SSO handoff redemption failed', ['already_claimed' => false]);
+        }
+
+        return $payload;
     }
 }

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -46,10 +46,19 @@ class AdminSsoHandoff
     }
 
     /**
-     * Single-use: pull deletes atomically, so a second redemption is null.
+     * Single-use: Cache::pull() alone is get-then-forget (not atomic on
+     * redis), so claim the token with an atomic add() first — the same
+     * discipline as the SAML assertion replay guard — making concurrent
+     * redemptions of one token impossible.
      */
     public function redeem(string $token): ?array
     {
-        return Cache::store(config('saml.replay_store'))->pull(self::KEY_PREFIX.$token);
+        $store = Cache::store(config('saml.replay_store'));
+
+        if (! $store->add(self::KEY_PREFIX.'claim:'.$token, 1, (int) config('saml.admin_handoff_ttl'))) {
+            return null;
+        }
+
+        return $store->pull(self::KEY_PREFIX.$token);
     }
 }

--- a/app/Saml/AdminSsoHandoff.php
+++ b/app/Saml/AdminSsoHandoff.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Saml;
+
+use App\Models\Employee;
+use App\Models\SamlClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Bridges a validated admin-portal SAML assertion into the legacy portal's
+ * own session world: match an active Employee (fail closed, never JIT),
+ * mint a short-lived single-use token, and send the browser to the portal's
+ * ssoLogon.php, which redeems the token server-side through the admin API.
+ */
+class AdminSsoHandoff
+{
+    private const KEY_PREFIX = 'admin_sso:token:';
+
+    public function initiate(SamlClient $client, string $email): string
+    {
+        $employee = Employee::where('Email', $email)->where('Active', 'Y')->first();
+
+        if (! $employee) {
+            throw new SamlLoginRejected(
+                'Your account is not authorized for the admin portal. Contact your administrator.',
+                ['reason' => 'no_employee_match', 'email' => $email],
+            );
+        }
+
+        $token = Str::random(64);
+
+        Cache::store(config('saml.replay_store'))->put(
+            self::KEY_PREFIX.$token,
+            ['employee_id' => $employee->ID, 'name' => $employee->FirstName.' '.$employee->LastName],
+            (int) config('saml.admin_handoff_ttl'),
+        );
+
+        Log::info('SAML admin portal login', [
+            'client' => $client->slug,
+            'employee_id' => $employee->ID,
+        ]);
+
+        return rtrim(config('saml.admin_portal_url'), '/').'/ssoLogon.php?token='.$token;
+    }
+
+    /**
+     * Single-use: pull deletes atomically, so a second redemption is null.
+     */
+    public function redeem(string $token): ?array
+    {
+        return Cache::store(config('saml.replay_store'))->pull(self::KEY_PREFIX.$token);
+    }
+}

--- a/app/Saml/AttributeRouter.php
+++ b/app/Saml/AttributeRouter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Saml;
+
+use App\Models\Department;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+
+/**
+ * Two-stage placement from a SAML assertion's attributes (spec:
+ * docs/specs/2026-07-10-attribute-routing.md). Stage 1 answers "which
+ * organization": the owner for org-owned clients, the ordered org rules for
+ * system-owned ones. Stage 2 answers "which department" by NAME within the
+ * resolved org — first rule that matches AND resolves wins, so shared rule
+ * sets survive orgs that lack a given department.
+ */
+class AttributeRouter
+{
+    /**
+     * @param  array<string, array<int, mixed>>  $attributes  php-saml getAttributes()
+     * @return array{organization_id: int, department_id: ?int}|null
+     */
+    public function route(SamlClient $client, array $attributes, ?int $fallbackOrganizationId = null): ?array
+    {
+        $organizationId = $this->resolveOrganization($client, $attributes) ?? $fallbackOrganizationId;
+
+        if ($organizationId === null) {
+            return null;
+        }
+
+        return [
+            'organization_id' => $organizationId,
+            'department_id' => $this->resolveDepartment($client, $attributes, $organizationId),
+        ];
+    }
+
+    private function resolveOrganization(SamlClient $client, array $attributes): ?int
+    {
+        if ($client->ownedByOrganization()) {
+            return $client->owner_id;
+        }
+
+        foreach ($client->orgRules as $rule) {
+            if ($this->ruleMatches($rule, $attributes)) {
+                return $rule->organization_id;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveDepartment(SamlClient $client, array $attributes, int $organizationId): ?int
+    {
+        // One query: the resolved org's active departments, name → ID,
+        // lowercased for the case-insensitive rule-name resolution.
+        $departments = Department::where('OrganizationID', $organizationId)
+            ->where('Active', 'Y')
+            ->pluck('ID', 'Name')
+            ->mapWithKeys(fn ($id, $name) => [mb_strtolower($name) => (int) $id]);
+
+        foreach ($client->departmentRules as $rule) {
+            $resolved = $departments->get(mb_strtolower($rule->department_name));
+
+            // Fall through when the name doesn't exist here: shared rule
+            // sets stay usable across orgs missing a department.
+            if ($resolved !== null && $this->ruleMatches($rule, $attributes)) {
+                return $resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private function ruleMatches(SamlOrgRule|SamlDepartmentRule $rule, array $attributes): bool
+    {
+        if ($rule->isCatchAll()) {
+            return true;
+        }
+
+        return $rule->operator->matchesAny($attributes[$rule->attribute] ?? [], $rule->value);
+    }
+}

--- a/app/Saml/AttributeRouter.php
+++ b/app/Saml/AttributeRouter.php
@@ -6,6 +6,7 @@ use App\Models\Department;
 use App\Models\SamlClient;
 use App\Models\SamlDepartmentRule;
 use App\Models\SamlOrgRule;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Two-stage placement from a SAML assertion's attributes (spec:
@@ -14,6 +15,10 @@ use App\Models\SamlOrgRule;
  * system-owned ones. Stage 2 answers "which department" by NAME within the
  * resolved org — first rule that matches AND resolves wins, so shared rule
  * sets survive orgs that lack a given department.
+ *
+ * Otherwise a pure function over its inputs — one `Departments` query per
+ * login on the resolved org, plus the scope query for system-owned clients —
+ * logs only the stale-scope warning (no user lookups, no session).
  */
 class AttributeRouter
 {
@@ -41,10 +46,28 @@ class AttributeRouter
             return $client->owner_id;
         }
 
+        // Defense-in-depth against stale rules left behind by a re-parent
+        // that predates the manager-level guard (or a direct DB edit): a
+        // rule targeting an org outside the client's current scope is
+        // skipped rather than trusted, and the skip is logged so it gets
+        // noticed and cleaned up.
+        $scope = $client->scopedOrganizationIds();
+
         foreach ($client->orgRules as $rule) {
-            if ($this->ruleMatches($rule, $attributes)) {
-                return $rule->organization_id;
+            if (! $this->ruleMatches($rule, $attributes)) {
+                continue;
             }
+
+            if (! in_array($rule->organization_id, $scope, true)) {
+                Log::warning('Routing rule targets organization outside client scope', [
+                    'client' => $client->slug,
+                    'organization_id' => $rule->organization_id,
+                ]);
+
+                continue;
+            }
+
+            return $rule->organization_id;
         }
 
         return null;
@@ -52,10 +75,18 @@ class AttributeRouter
 
     private function resolveDepartment(SamlClient $client, array $attributes, int $organizationId): ?int
     {
+        if ($client->departmentRules->isEmpty()) {
+            return null;
+        }
+
         // One query: the resolved org's active departments, name → ID,
         // lowercased for the case-insensitive rule-name resolution.
         $departments = Department::where('OrganizationID', $organizationId)
             ->where('Active', 'Y')
+            // duplicate names in an org resolve to the lowest ID, deterministically
+            // (descending order + pluck-overwrite semantics: the last-applied,
+            // lowest-ID row wins the keyed collection)
+            ->orderByDesc('ID')
             ->pluck('ID', 'Name')
             ->mapWithKeys(fn ($id, $name) => [mb_strtolower($name) => (int) $id]);
 

--- a/app/Saml/AttributeRouter.php
+++ b/app/Saml/AttributeRouter.php
@@ -28,6 +28,9 @@ class AttributeRouter
      */
     public function route(SamlClient $client, array $attributes, ?int $fallbackOrganizationId = null): ?array
     {
+        // Single round trip per login instead of two lazy loads (orgRules, then departmentRules).
+        $client->loadMissing(['orgRules', 'departmentRules']);
+
         $organizationId = $this->resolveOrganization($client, $attributes) ?? $fallbackOrganizationId;
 
         if ($organizationId === null) {

--- a/app/Saml/KnownAttributeCollector.php
+++ b/app/Saml/KnownAttributeCollector.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Log;
  */
 class KnownAttributeCollector
 {
-    public function capture(SamlClient $client, array $attributes): void
+    public function capture(SamlClient $client, array $attributeNames): void
     {
         try {
             // Admin-portal clients assert Employee identities, not routing
@@ -28,7 +28,7 @@ class KnownAttributeCollector
             // Exclude the identity attributes (the attribute_map's VALUES);
             // they're already handled by the fixed map and would be dropdown noise.
             $identity = array_values($client->attribute_map ?? []);
-            $candidates = array_values(array_diff(array_keys($attributes), $identity));
+            $candidates = array_values(array_diff($attributeNames, $identity));
 
             if ($candidates === []) {
                 return;
@@ -36,15 +36,31 @@ class KnownAttributeCollector
 
             $now = now();
 
-            foreach ($candidates as $name) {
-                $observation = SamlAttributeObservation::firstOrNew([
+            $existingNames = SamlAttributeObservation::query()
+                ->where('saml_client_id', $client->id)
+                ->whereIn('name', $candidates)
+                ->pluck('name')
+                ->all();
+
+            SamlAttributeObservation::upsert(
+                array_map(fn (string $name) => [
                     'saml_client_id' => $client->id,
                     'name' => $name,
-                ]);
-                $observation->first_seen_at ??= $now;
-                $observation->last_seen_at = $now;
-                $observation->observation_count = ($observation->observation_count ?? 0) + 1;
-                $observation->save();
+                    'first_seen_at' => $now,
+                    'last_seen_at' => $now,
+                    'observation_count' => 1,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ], $candidates),
+                ['saml_client_id', 'name'],       // unique-by (matches the migration's unique index)
+                ['last_seen_at', 'updated_at'],   // on duplicate: bump last_seen only; first_seen_at & count untouched
+            );
+
+            if ($existingNames !== []) {
+                SamlAttributeObservation::query()
+                    ->where('saml_client_id', $client->id)
+                    ->whereIn('name', $existingNames)
+                    ->increment('observation_count', 1, ['updated_at' => $now]);
             }
 
             $known = $client->known_attributes;

--- a/app/Saml/KnownAttributeCollector.php
+++ b/app/Saml/KnownAttributeCollector.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Saml;
+
+use App\Models\SamlAttributeObservation;
+use App\Models\SamlClient;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Records which attribute NAMES an IdP asserts, per client, so the routing
+ * rule editor can offer real attributes instead of hand-typed strings.
+ * Names only — values are PHI and are never read or stored (spec:
+ * docs/specs/2026-07-11-known-attributes.md). Runs on the login hot path
+ * after the assertion is validated; any failure is swallowed so it can
+ * never break a login.
+ */
+class KnownAttributeCollector
+{
+    public function capture(SamlClient $client, array $attributes): void
+    {
+        try {
+            // Admin-portal clients assert Employee identities, not routing
+            // attributes — nothing to capture.
+            if ($client->admin_portal) {
+                return;
+            }
+
+            // Exclude the identity attributes (the attribute_map's VALUES);
+            // they're already handled by the fixed map and would be dropdown noise.
+            $identity = array_values($client->attribute_map ?? []);
+            $candidates = array_values(array_diff(array_keys($attributes), $identity));
+
+            if ($candidates === []) {
+                return;
+            }
+
+            $now = now();
+
+            foreach ($candidates as $name) {
+                $observation = SamlAttributeObservation::firstOrNew([
+                    'saml_client_id' => $client->id,
+                    'name' => $name,
+                ]);
+                $observation->first_seen_at ??= $now;
+                $observation->last_seen_at = $now;
+                $observation->observation_count = ($observation->observation_count ?? 0) + 1;
+                $observation->save();
+            }
+
+            $known = $client->known_attributes;
+            $fresh = array_values(array_diff($candidates, $known));
+
+            if ($fresh !== []) {
+                $client->known_attributes = array_values(array_unique(array_merge($known, $fresh)));
+                $client->save();
+            }
+        } catch (\Throwable $e) {
+            Log::warning('known-attribute capture failed', [
+                'client' => $client->slug,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Saml/RoutingOperator.php
+++ b/app/Saml/RoutingOperator.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Saml;
+
+/**
+ * Match operators for routing rules — the single source of truth (spec:
+ * docs/specs/2026-07-10-attribute-routing.md). Models cast to this enum,
+ * validators use Rule::enum(), the router matches on cases, the API
+ * serializes ->value; nothing compares raw operator strings.
+ *
+ * All operators compare case-insensitively except StrictWildcard —
+ * Cloudflare's wildcard/strict-wildcard distinction, kept verbatim.
+ */
+enum RoutingOperator: string
+{
+    case Wildcard = 'wildcard';
+    case StrictWildcard = 'strict_wildcard';
+    case Equals = 'equals';
+    case NotEquals = 'not_equals';
+    case StartsWith = 'starts_with';
+    case NotStartsWith = 'not_starts_with';
+    case Contains = 'contains';
+    case NotContains = 'not_contains';
+    case EndsWith = 'ends_with';
+    case NotEndsWith = 'not_ends_with';
+
+    /**
+     * SAML attributes are multi-valued: positive operators match when ANY
+     * asserted value satisfies the comparison (absent attribute — an empty
+     * $assertedValues — never matches); negated operators match when NO
+     * asserted value satisfies the positive form (vacuously true when the
+     * attribute is absent).
+     */
+    public function matchesAny(array $assertedValues, string $ruleValue): bool
+    {
+        $anySatisfies = collect($assertedValues)
+            ->contains(fn ($asserted) => $this->satisfies((string) $asserted, $ruleValue));
+
+        return $this->isNegated() ? ! $anySatisfies : $anySatisfies;
+    }
+
+    private function isNegated(): bool
+    {
+        return match ($this) {
+            self::NotEquals, self::NotStartsWith, self::NotContains, self::NotEndsWith => true,
+            default => false,
+        };
+    }
+
+    private function satisfies(string $asserted, string $ruleValue): bool
+    {
+        $a = mb_strtolower($asserted);
+        $v = mb_strtolower($ruleValue);
+
+        return match ($this) {
+            self::Wildcard => self::wildcardMatch($asserted, $ruleValue, caseSensitive: false),
+            self::StrictWildcard => self::wildcardMatch($asserted, $ruleValue, caseSensitive: true),
+            self::Equals, self::NotEquals => $a === $v,
+            self::StartsWith, self::NotStartsWith => str_starts_with($a, $v),
+            self::Contains, self::NotContains => str_contains($a, $v),
+            self::EndsWith, self::NotEndsWith => str_ends_with($a, $v),
+        };
+    }
+
+    /**
+     * Anchored *-pattern: * matches zero or more characters, everything
+     * else is literal.
+     */
+    private static function wildcardMatch(string $asserted, string $pattern, bool $caseSensitive): bool
+    {
+        $regex = '/^'.str_replace('\*', '.*', preg_quote($pattern, '/')).'$/u'
+            .($caseSensitive ? '' : 'i');
+
+        return (bool) preg_match($regex, $asserted);
+    }
+}

--- a/app/Saml/RoutingOperator.php
+++ b/app/Saml/RoutingOperator.php
@@ -49,16 +49,13 @@ enum RoutingOperator: string
 
     private function satisfies(string $asserted, string $ruleValue): bool
     {
-        $a = mb_strtolower($asserted);
-        $v = mb_strtolower($ruleValue);
-
         return match ($this) {
             self::Wildcard => self::wildcardMatch($asserted, $ruleValue, caseSensitive: false),
             self::StrictWildcard => self::wildcardMatch($asserted, $ruleValue, caseSensitive: true),
-            self::Equals, self::NotEquals => $a === $v,
-            self::StartsWith, self::NotStartsWith => str_starts_with($a, $v),
-            self::Contains, self::NotContains => str_contains($a, $v),
-            self::EndsWith, self::NotEndsWith => str_ends_with($a, $v),
+            self::Equals, self::NotEquals => mb_strtolower($asserted) === mb_strtolower($ruleValue),
+            self::StartsWith, self::NotStartsWith => str_starts_with(mb_strtolower($asserted), mb_strtolower($ruleValue)),
+            self::Contains, self::NotContains => str_contains(mb_strtolower($asserted), mb_strtolower($ruleValue)),
+            self::EndsWith, self::NotEndsWith => str_ends_with(mb_strtolower($asserted), mb_strtolower($ruleValue)),
         };
     }
 
@@ -71,6 +68,8 @@ enum RoutingOperator: string
         $regex = '/^'.str_replace('\*', '.*', preg_quote($pattern, '/')).'$/u'
             .($caseSensitive ? '' : 'i');
 
+        // Malformed UTF-8 in $asserted makes preg_match return false (not 0/1);
+        // the (bool) cast folds that into "no match" rather than throwing, by design.
         return (bool) preg_match($regex, $asserted);
     }
 }

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -101,6 +101,12 @@ class SamlClientManager
 
     public function update(SamlClient $client, array $input): SamlClient
     {
+        if (array_key_exists('owner_type', $input) !== array_key_exists('owner_id', $input)) {
+            throw ValidationException::withMessages([
+                'owner_id' => 'Re-parenting requires owner_type and owner_id together.',
+            ]);
+        }
+
         if (isset($input['email_domains'])) {
             $input['email_domains'] = $this->normalizeDomains($input['email_domains']);
         }
@@ -108,8 +114,8 @@ class SamlClientManager
         $validated = Validator::make($input, [
             'name' => ['sometimes', 'required', 'string', 'max:255'],
             'slug' => ['sometimes', 'required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug,'.$client->id],
-            'owner_type' => ['sometimes', 'required', 'in:organization,system', 'required_with:owner_id'],
-            'owner_id' => ['sometimes', 'required', 'integer', 'min:1', 'required_with:owner_type'],
+            'owner_type' => ['sometimes', 'required', 'in:organization,system'],
+            'owner_id' => ['sometimes', 'required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
             'admin_portal' => ['sometimes', 'boolean'],

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -140,6 +140,7 @@ class SamlClientManager
             $validated['owner_id'] ?? $client->owner_id,
             array_key_exists('department_id', $validated) ? $validated['department_id'] : $client->department_id,
         );
+        $this->assertNoRoutingRulesWhenReparenting($client, $validated);
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $client);
 
@@ -380,6 +381,36 @@ class SamlClientManager
         if (! $belongs) {
             throw ValidationException::withMessages([
                 'department_id' => 'Department does not belong to the owning organization.',
+            ]);
+        }
+    }
+
+    /**
+     * Routing rules are keyed to the client's current owner (org rules
+     * target orgs in its scope, department rules assume its owner's org
+     * tree) — re-parenting out from under them would silently leave rules
+     * pointing at the wrong hierarchy. Require clearing them first.
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    private function assertNoRoutingRulesWhenReparenting(SamlClient $client, array $validated): void
+    {
+        $reparenting = array_key_exists('owner_type', $validated) || array_key_exists('owner_id', $validated);
+
+        if (! $reparenting) {
+            return;
+        }
+
+        $ownerChanging = ($validated['owner_type'] ?? $client->owner_type) !== $client->owner_type
+            || ($validated['owner_id'] ?? $client->owner_id) !== $client->owner_id;
+
+        if (! $ownerChanging) {
+            return;
+        }
+
+        if ($client->orgRules()->exists() || $client->departmentRules()->exists()) {
+            throw ValidationException::withMessages([
+                'owner_id' => 'Clear routing rules before re-parenting this client.',
             ]);
         }
     }

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -61,6 +61,7 @@ class SamlClientManager
             'organization_id' => ['required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
+            'admin_portal' => ['sometimes', 'boolean'],
             'attribute_map' => ['sometimes', 'array'],
             'attribute_map.email' => ['required_with:attribute_map', 'string'],
             'attribute_map.first_name' => ['sometimes', 'string'],
@@ -70,6 +71,11 @@ class SamlClientManager
         ])->validate();
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], null);
+
+        $this->assertAdminPortalHoldsNoDomains(
+            (bool) ($validated['admin_portal'] ?? false),
+            $validated['email_domains'] ?? [],
+        );
 
         return SamlClient::create($validated + [
             'enabled' => false, // enabled explicitly once IdP metadata is in place
@@ -94,6 +100,7 @@ class SamlClientManager
             'organization_id' => ['sometimes', 'required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
+            'admin_portal' => ['sometimes', 'boolean'],
             'attribute_map' => ['sometimes', 'array'],
             'attribute_map.email' => ['required_with:attribute_map', 'string'],
             'attribute_map.first_name' => ['sometimes', 'string'],
@@ -103,6 +110,11 @@ class SamlClientManager
         ])->validate();
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $client);
+
+        $this->assertAdminPortalHoldsNoDomains(
+            (bool) ($validated['admin_portal'] ?? $client->admin_portal),
+            $validated['email_domains'] ?? ($client->email_domains ?? []),
+        );
 
         $client->update($validated);
 
@@ -171,6 +183,19 @@ class SamlClientManager
                     'email_domains' => "Domain {$domain} is already claimed by another SAML client.",
                 ]);
             }
+        }
+    }
+
+    /**
+     * Admin-portal clients assert Employee identities and never participate
+     * in customer email-domain routing (spec: admin portal SSO).
+     */
+    private function assertAdminPortalHoldsNoDomains(bool $adminPortal, array $domains): void
+    {
+        if ($adminPortal && $domains !== []) {
+            throw ValidationException::withMessages([
+                'email_domains' => 'An admin-portal client cannot claim email domains.',
+            ]);
         }
     }
 }

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -2,7 +2,10 @@
 
 namespace App\Saml;
 
+use App\Models\Department;
+use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
@@ -58,6 +61,7 @@ class SamlClientManager
         $validated = Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'slug' => ['required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug'],
+            'owner_type' => ['required', 'in:organization,system'],
             'owner_id' => ['required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
@@ -69,6 +73,13 @@ class SamlClientManager
             'email_domains' => ['sometimes', 'array'],
             'email_domains.*' => ['string', 'regex:/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/'],
         ])->validate();
+
+        $this->assertOwnerExists($validated['owner_type'], $validated['owner_id']);
+        $this->assertDefaultDepartmentValid(
+            $validated['owner_type'],
+            $validated['owner_id'],
+            $validated['department_id'] ?? null,
+        );
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], null);
 
@@ -85,9 +96,6 @@ class SamlClientManager
             'idp_certificate' => 'pending',
             'attribute_map' => self::DEFAULT_ATTRIBUTE_MAP,
             'email_domains' => [],
-            // Every client created through this manager is org-owned for now;
-            // system ownership is created another way (Task 2).
-            'owner_type' => 'organization',
         ]);
     }
 
@@ -100,7 +108,8 @@ class SamlClientManager
         $validated = Validator::make($input, [
             'name' => ['sometimes', 'required', 'string', 'max:255'],
             'slug' => ['sometimes', 'required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug,'.$client->id],
-            'owner_id' => ['sometimes', 'required', 'integer', 'min:1'],
+            'owner_type' => ['sometimes', 'required', 'in:organization,system', 'required_with:owner_id'],
+            'owner_id' => ['sometimes', 'required', 'integer', 'min:1', 'required_with:owner_type'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
             'admin_portal' => ['sometimes', 'boolean'],
@@ -111,6 +120,16 @@ class SamlClientManager
             'email_domains' => ['sometimes', 'array'],
             'email_domains.*' => ['string', 'regex:/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/'],
         ])->validate();
+
+        $this->assertOwnerExists(
+            $validated['owner_type'] ?? $client->owner_type,
+            $validated['owner_id'] ?? $client->owner_id,
+        );
+        $this->assertDefaultDepartmentValid(
+            $validated['owner_type'] ?? $client->owner_type,
+            $validated['owner_id'] ?? $client->owner_id,
+            array_key_exists('department_id', $validated) ? $validated['department_id'] : $client->department_id,
+        );
 
         $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $client);
 
@@ -198,6 +217,47 @@ class SamlClientManager
         if ($adminPortal && $domains !== []) {
             throw ValidationException::withMessages([
                 'email_domains' => 'An admin-portal client cannot claim email domains.',
+            ]);
+        }
+    }
+
+    private function assertOwnerExists(string $ownerType, int $ownerId): void
+    {
+        $exists = $ownerType === 'organization'
+            ? Organization::where('ID', $ownerId)->exists()
+            : System::where('ID', $ownerId)->exists();
+
+        if (! $exists) {
+            throw ValidationException::withMessages([
+                'owner_id' => "No {$ownerType} with ID {$ownerId}.",
+            ]);
+        }
+    }
+
+    /**
+     * A default department only makes sense on an org-owned client and must
+     * belong to the owning organization (closes the milestone-4 gap where
+     * department_id was never validated).
+     */
+    private function assertDefaultDepartmentValid(string $ownerType, int $ownerId, ?int $departmentId): void
+    {
+        if ($departmentId === null) {
+            return;
+        }
+
+        if ($ownerType !== 'organization') {
+            throw ValidationException::withMessages([
+                'department_id' => 'A default department requires an organization-owned client.',
+            ]);
+        }
+
+        $belongs = Department::where('ID', $departmentId)
+            ->where('OrganizationID', $ownerId)
+            ->exists();
+
+        if (! $belongs) {
+            throw ValidationException::withMessages([
+                'department_id' => 'Department does not belong to the owning organization.',
             ]);
         }
     }

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -5,10 +5,14 @@ namespace App\Saml;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
 use App\Models\System;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 use OneLogin\Saml2\IdPMetadataParser;
@@ -161,6 +165,118 @@ class SamlClientManager
         $client->update(['enabled' => $enabled]);
 
         return $client->refresh();
+    }
+
+    /**
+     * Replace both ordered rule lists wholesale. Validates everything —
+     * shape, owner-kind, scope membership, catch-all placement — before any
+     * write; positions are derived from array order. Audit logging is the
+     * API layer's job (Task 6), not the manager's.
+     *
+     * @param  array<int, array<string, mixed>>  $orgRules
+     * @param  array<int, array<string, mixed>>  $departmentRules
+     */
+    public function replaceRoutingRules(SamlClient $client, array $orgRules, array $departmentRules): SamlClient
+    {
+        if ($orgRules !== [] && $client->ownedByOrganization()) {
+            throw ValidationException::withMessages([
+                'org_rules' => 'Organization rules require a system-owned client.',
+            ]);
+        }
+
+        Validator::make(
+            ['org_rules' => $orgRules, 'department_rules' => $departmentRules],
+            [
+                'org_rules' => ['array'],
+                'org_rules.*.attribute' => ['required', 'string'],
+                'org_rules.*.operator' => ['required', Rule::enum(RoutingOperator::class)],
+                'org_rules.*.value' => ['required', 'string'],
+                'org_rules.*.organization_id' => ['required', 'integer'],
+                'department_rules' => ['array'],
+                'department_rules.*.attribute' => ['required', 'string'],
+                'department_rules.*.operator' => ['required', Rule::enum(RoutingOperator::class)],
+                'department_rules.*.value' => ['required', 'string'],
+                'department_rules.*.department_name' => ['required', 'string'],
+            ]
+        )->validate();
+
+        $scope = $client->scopedOrganizationIds();
+
+        foreach ($orgRules as $index => $rule) {
+            if (! in_array((int) $rule['organization_id'], $scope, true)) {
+                throw ValidationException::withMessages([
+                    "org_rules.{$index}.organization_id" => "Organization is outside this client's scope.",
+                ]);
+            }
+        }
+
+        $this->assertCatchAllPlacement($orgRules, 'org_rules');
+        $this->assertCatchAllPlacement($departmentRules, 'department_rules');
+
+        DB::transaction(function () use ($client, $orgRules, $departmentRules) {
+            SamlOrgRule::where('saml_client_id', $client->id)->delete();
+            SamlDepartmentRule::where('saml_client_id', $client->id)->delete();
+
+            foreach ($orgRules as $index => $rule) {
+                SamlOrgRule::create([
+                    'saml_client_id' => $client->id,
+                    'position' => $index + 1,
+                    'attribute' => $rule['attribute'],
+                    'operator' => $rule['operator'],
+                    'value' => $rule['value'],
+                    'organization_id' => $rule['organization_id'],
+                ]);
+            }
+
+            foreach ($departmentRules as $index => $rule) {
+                SamlDepartmentRule::create([
+                    'saml_client_id' => $client->id,
+                    'position' => $index + 1,
+                    'attribute' => $rule['attribute'],
+                    'operator' => $rule['operator'],
+                    'value' => $rule['value'],
+                    'department_name' => $rule['department_name'],
+                ]);
+            }
+        });
+
+        return $client->refresh();
+    }
+
+    /**
+     * The `*` attribute is reserved for the catch-all triple
+     * (wildcard/*\/*): any other use of `*` is rejected, and a catch-all may
+     * only appear as the last rule in its list — anything after it can never
+     * be reached.
+     *
+     * @param  array<int, array<string, mixed>>  $rules
+     */
+    private function assertCatchAllPlacement(array $rules, string $field): void
+    {
+        $catchAllIndex = null;
+
+        foreach ($rules as $index => $rule) {
+            $isWildcardAttribute = $rule['attribute'] === '*';
+            $isCatchAllTriple = $isWildcardAttribute
+                && ($rule['operator'] ?? null) === RoutingOperator::Wildcard->value
+                && ($rule['value'] ?? null) === '*';
+
+            if ($isWildcardAttribute && ! $isCatchAllTriple) {
+                throw ValidationException::withMessages([
+                    "{$field}.{$index}.attribute" => 'The * attribute is reserved for the catch-all rule (wildcard, *).',
+                ]);
+            }
+
+            if ($catchAllIndex !== null) {
+                throw ValidationException::withMessages([
+                    "{$field}.{$index}" => 'Rules after a catch-all are unreachable.',
+                ]);
+            }
+
+            if ($isCatchAllTriple) {
+                $catchAllIndex = $index;
+            }
+        }
     }
 
     /**

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -20,6 +20,9 @@ use OneLogin\Saml2\Utils;
 
 class SamlClientManager
 {
+    /** Field names this manager's validators accept — the audit layer reports exactly these. */
+    public const EDITABLE_FIELDS = ['name', 'slug', 'owner_type', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
+
     /**
      * Extract entity ID, SSO URL, and signing certificate from IdP metadata XML.
      *
@@ -62,35 +65,10 @@ class SamlClientManager
             $input['email_domains'] = $this->normalizeDomains($input['email_domains']);
         }
 
-        $validated = Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
-            'slug' => ['required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug'],
-            'owner_type' => ['required', 'in:organization,system'],
-            'owner_id' => ['required', 'integer', 'min:1'],
-            'department_id' => ['nullable', 'integer', 'min:1'],
-            'jit_enabled' => ['sometimes', 'boolean'],
-            'admin_portal' => ['sometimes', 'boolean'],
-            'attribute_map' => ['sometimes', 'array'],
-            'attribute_map.email' => ['required_with:attribute_map', 'string'],
-            'attribute_map.first_name' => ['sometimes', 'string'],
-            'attribute_map.last_name' => ['sometimes', 'string'],
-            'email_domains' => ['sometimes', 'array'],
-            'email_domains.*' => ['string', 'regex:/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/'],
-        ])->validate();
+        $validated = Validator::make($input, $this->rules(forUpdate: false))->validate();
 
-        $this->assertOwnerExists($validated['owner_type'], $validated['owner_id']);
-        $this->assertDefaultDepartmentValid(
-            $validated['owner_type'],
-            $validated['owner_id'],
-            $validated['department_id'] ?? null,
-        );
-
-        $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], null);
-
-        $this->assertAdminPortalHoldsNoDomains(
-            (bool) ($validated['admin_portal'] ?? false),
-            $validated['email_domains'] ?? [],
-        );
+        $this->assertOwnerAndDepartmentValid($validated, null);
+        $this->assertDomainInvariants($validated, null);
 
         return SamlClient::create($validated + [
             'enabled' => false, // enabled explicitly once IdP metadata is in place
@@ -115,11 +93,38 @@ class SamlClientManager
             $input['email_domains'] = $this->normalizeDomains($input['email_domains']);
         }
 
-        $validated = Validator::make($input, [
-            'name' => ['sometimes', 'required', 'string', 'max:255'],
-            'slug' => ['sometimes', 'required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug,'.$client->id],
-            'owner_type' => ['sometimes', 'required', 'in:organization,system'],
-            'owner_id' => ['sometimes', 'required', 'integer', 'min:1'],
+        $validated = Validator::make($input, $this->rules(forUpdate: true, client: $client))->validate();
+
+        $this->assertOwnerAndDepartmentValid($validated, $client);
+        $this->assertNoRoutingRulesWhenReparenting($client, $validated);
+        $this->assertDomainInvariants($validated, $client);
+
+        $client->update($validated);
+
+        return $client->refresh();
+    }
+
+    /**
+     * Validation rules for create() and update() — identical except that
+     * update() makes name/owner_type/owner_id optional (`sometimes`) and
+     * scopes the slug uniqueness check to exclude the client being updated.
+     *
+     * @return array<string, mixed>
+     */
+    private function rules(bool $forUpdate, ?SamlClient $client = null): array
+    {
+        $slugUnique = $forUpdate
+            ? 'unique:saml_clients,slug,'.$client->id
+            : 'unique:saml_clients,slug';
+
+        return [
+            'name' => $forUpdate ? ['sometimes', 'required', 'string', 'max:255'] : ['required', 'string', 'max:255'],
+            'slug' => array_merge(
+                $forUpdate ? ['sometimes', 'required'] : ['required'],
+                ['string', 'max:64', 'alpha_dash', $slugUnique],
+            ),
+            'owner_type' => $forUpdate ? ['sometimes', 'required', 'in:organization,system'] : ['required', 'in:organization,system'],
+            'owner_id' => $forUpdate ? ['sometimes', 'required', 'integer', 'min:1'] : ['required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
             'admin_portal' => ['sometimes', 'boolean'],
@@ -129,29 +134,47 @@ class SamlClientManager
             'attribute_map.last_name' => ['sometimes', 'string'],
             'email_domains' => ['sometimes', 'array'],
             'email_domains.*' => ['string', 'regex:/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/'],
-        ])->validate();
+        ];
+    }
 
-        $this->assertOwnerExists(
-            $validated['owner_type'] ?? $client->owner_type,
-            $validated['owner_id'] ?? $client->owner_id,
-        );
-        $this->assertDefaultDepartmentValid(
-            $validated['owner_type'] ?? $client->owner_type,
-            $validated['owner_id'] ?? $client->owner_id,
-            array_key_exists('department_id', $validated) ? $validated['department_id'] : $client->department_id,
-        );
-        $this->assertNoRoutingRulesWhenReparenting($client, $validated);
+    /**
+     * First two of the four post-validation asserts shared by create() and
+     * update(): owner exists, and the default department (if any) is valid
+     * for that owner. On create $existing is null, so every fallback
+     * resolves to the request's own defaults; on update, an omitted field
+     * falls back to the existing client's current value.
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    private function assertOwnerAndDepartmentValid(array $validated, ?SamlClient $existing): void
+    {
+        $ownerType = $validated['owner_type'] ?? $existing?->owner_type;
+        $ownerId = $validated['owner_id'] ?? $existing?->owner_id;
 
-        $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $client);
+        $this->assertOwnerExists($ownerType, $ownerId);
+
+        $departmentId = $existing !== null && ! array_key_exists('department_id', $validated)
+            ? $existing->department_id
+            : ($validated['department_id'] ?? null);
+
+        $this->assertDefaultDepartmentValid($ownerType, $ownerId, $departmentId);
+    }
+
+    /**
+     * Last two of the four shared asserts: the requested domains aren't
+     * claimed elsewhere, and admin-portal clients hold no domains. Same
+     * $existing/fallback contract as assertOwnerAndDepartmentValid().
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    private function assertDomainInvariants(array $validated, ?SamlClient $existing): void
+    {
+        $this->assertDomainsUnclaimed($validated['email_domains'] ?? [], $existing);
 
         $this->assertAdminPortalHoldsNoDomains(
-            (bool) ($validated['admin_portal'] ?? $client->admin_portal),
-            $validated['email_domains'] ?? ($client->email_domains ?? []),
+            (bool) ($validated['admin_portal'] ?? $existing?->admin_portal ?? false),
+            $validated['email_domains'] ?? ($existing?->email_domains ?? []),
         );
-
-        $client->update($validated);
-
-        return $client->refresh();
     }
 
     public function updateFromIdpMetadata(SamlClient $client, string $xml): SamlClient

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -21,7 +21,7 @@ use OneLogin\Saml2\Utils;
 class SamlClientManager
 {
     /** Field names this manager's validators accept — the audit layer reports exactly these. */
-    public const EDITABLE_FIELDS = ['name', 'slug', 'owner_type', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map'];
+    public const EDITABLE_FIELDS = ['name', 'slug', 'owner_type', 'owner_id', 'department_id', 'jit_enabled', 'admin_portal', 'email_domains', 'attribute_map', 'known_attributes'];
 
     /**
      * Extract entity ID, SSO URL, and signing certificate from IdP metadata XML.
@@ -67,6 +67,10 @@ class SamlClientManager
 
         $validated = Validator::make($input, $this->rules(forUpdate: false))->validate();
 
+        if (isset($validated['known_attributes'])) {
+            $validated['known_attributes'] = $this->normalizeAttributeNames($validated['known_attributes']);
+        }
+
         $this->assertOwnerAndDepartmentValid($validated, null);
         $this->assertDomainInvariants($validated, null);
 
@@ -94,6 +98,10 @@ class SamlClientManager
         }
 
         $validated = Validator::make($input, $this->rules(forUpdate: true, client: $client))->validate();
+
+        if (isset($validated['known_attributes'])) {
+            $validated['known_attributes'] = $this->normalizeAttributeNames($validated['known_attributes']);
+        }
 
         $this->assertOwnerAndDepartmentValid($validated, $client);
         $this->assertNoRoutingRulesWhenReparenting($client, $validated);
@@ -134,6 +142,8 @@ class SamlClientManager
             'attribute_map.last_name' => ['sometimes', 'string'],
             'email_domains' => ['sometimes', 'array'],
             'email_domains.*' => ['string', 'regex:/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/'],
+            'known_attributes' => ['sometimes', 'array'],
+            'known_attributes.*' => ['string'],
         ];
     }
 
@@ -332,6 +342,18 @@ class SamlClientManager
         return array_values(array_unique(array_map(
             fn ($domain) => strtolower(ltrim(trim((string) $domain), '@')),
             $domains,
+        )));
+    }
+
+    /**
+     * @param  array<int, string>  $names  Already validated as strings by the `known_attributes.*` rule.
+     * @return array<int, string>
+     */
+    private function normalizeAttributeNames(array $names): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map(fn ($n) => trim((string) $n), $names),
+            fn ($n) => $n !== '',
         )));
     }
 

--- a/app/Saml/SamlClientManager.php
+++ b/app/Saml/SamlClientManager.php
@@ -58,7 +58,7 @@ class SamlClientManager
         $validated = Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'slug' => ['required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug'],
-            'organization_id' => ['required', 'integer', 'min:1'],
+            'owner_id' => ['required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
             'admin_portal' => ['sometimes', 'boolean'],
@@ -85,6 +85,9 @@ class SamlClientManager
             'idp_certificate' => 'pending',
             'attribute_map' => self::DEFAULT_ATTRIBUTE_MAP,
             'email_domains' => [],
+            // Every client created through this manager is org-owned for now;
+            // system ownership is created another way (Task 2).
+            'owner_type' => 'organization',
         ]);
     }
 
@@ -97,7 +100,7 @@ class SamlClientManager
         $validated = Validator::make($input, [
             'name' => ['sometimes', 'required', 'string', 'max:255'],
             'slug' => ['sometimes', 'required', 'string', 'max:64', 'alpha_dash', 'unique:saml_clients,slug,'.$client->id],
-            'organization_id' => ['sometimes', 'required', 'integer', 'min:1'],
+            'owner_id' => ['sometimes', 'required', 'integer', 'min:1'],
             'department_id' => ['nullable', 'integer', 'min:1'],
             'jit_enabled' => ['sometimes', 'boolean'],
             'admin_portal' => ['sometimes', 'boolean'],

--- a/app/Saml/SamlUserProvisioner.php
+++ b/app/Saml/SamlUserProvisioner.php
@@ -31,6 +31,16 @@ class SamlUserProvisioner
             );
         }
 
+        if (! $client->ownedByOrganization()) {
+            // A system-owned client has no home org to aim the finish-account
+            // flow at; placement comes from routing rules (milestone 5). Until
+            // a rule matches, new users are rejected fail-closed.
+            throw new SamlLoginRejected(
+                'Your account could not be placed automatically. Please contact your administrator.',
+                ['reason' => 'unrouted_user', 'login' => $email],
+            );
+        }
+
         $user = User::factory()->newModel()->forceFill([
             'Login' => $email,
             // Placeholder when the IdP omitted a name; SamlController logs that misconfiguration.

--- a/app/Saml/SamlUserProvisioner.php
+++ b/app/Saml/SamlUserProvisioner.php
@@ -5,11 +5,15 @@ namespace App\Saml;
 use App\Models\SamlClient;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class SamlUserProvisioner
 {
-    public function provision(SamlClient $client, string $email, ?string $firstName, ?string $lastName): User
+    /**
+     * @param  array{organization_id: int, department_id: ?int}|null  $placement
+     */
+    public function provision(SamlClient $client, string $email, ?string $firstName, ?string $lastName, ?array $placement = null): User
     {
         $user = User::where('Login', $email)->first();
 
@@ -21,7 +25,21 @@ class SamlUserProvisioner
         }
 
         if ($user) {
-            return $this->syncName($user, $firstName, $lastName);
+            $user = $this->syncName($user, $firstName, $lastName);
+
+            $routedDepartment = $placement['department_id'] ?? null;
+
+            if ($routedDepartment !== null && $routedDepartment !== (int) $user->DepartmentID) {
+                $from = $user->DepartmentID;
+                $user->DepartmentID = $routedDepartment;
+                $user->save();
+
+                Log::info('SAML routed user to department', [
+                    'client' => $client->slug, 'user_id' => $user->ID, 'from' => $from, 'to' => $routedDepartment,
+                ]);
+            }
+
+            return $user;
         }
 
         if (! $client->jit_enabled) {
@@ -31,10 +49,10 @@ class SamlUserProvisioner
             );
         }
 
-        if (! $client->ownedByOrganization()) {
+        if ($placement === null && ! $client->ownedByOrganization()) {
             // A system-owned client has no home org to aim the finish-account
-            // flow at; placement comes from routing rules (milestone 5). Until
-            // a rule matches, new users are rejected fail-closed.
+            // flow at, and no routing rule (incl. catch-all) claimed this
+            // login — reject fail-closed rather than guess a placement.
             throw new SamlLoginRejected(
                 'Your account could not be placed automatically. Please contact your administrator.',
                 ['reason' => 'unrouted_user', 'login' => $email],
@@ -47,7 +65,11 @@ class SamlUserProvisioner
             'FirstName' => $firstName ?? 'FirstName',
             'LastName' => $lastName ?? 'LastName',
             // Legacy schema: DepartmentID is NOT NULL; 0 routes through finishAccountCreation
-            'DepartmentID' => $client->department_id ?? 0,
+            // A resolved department rule wins; otherwise org-owned clients
+            // keep their static default, and system-owned placements land in
+            // the finish flow of the placed org (DepartmentID 0).
+            'DepartmentID' => $placement['department_id']
+                ?? ($client->ownedByOrganization() ? ($client->department_id ?? 0) : 0),
             'CredentialID' => 0,
             'Password' => Hash::make(Str::random(40)),
             'CreationDate' => now()->format('Y-m-d H:i:s'),

--- a/app/Saml/SamlUserProvisioner.php
+++ b/app/Saml/SamlUserProvisioner.php
@@ -12,10 +12,13 @@ class SamlUserProvisioner
 {
     /**
      * @param  array{organization_id: int, department_id: ?int}|null  $placement
+     * @param  ?User  $existing  Pre-fetched by the caller (e.g. SamlController::acs()
+     *                           already reads this for routing) — skips the internal
+     *                           re-query when provided.
      */
-    public function provision(SamlClient $client, string $email, ?string $firstName, ?string $lastName, ?array $placement = null): User
+    public function provision(SamlClient $client, string $email, ?string $firstName, ?string $lastName, ?array $placement = null, ?User $existing = null): User
     {
-        $user = User::where('Login', $email)->first();
+        $user = $existing ?? User::where('Login', $email)->first();
 
         if ($user && $user->Disabled === 'Y') {
             throw new SamlLoginRejected(

--- a/app/Support/AdminAudit.php
+++ b/app/Support/AdminAudit.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AdminAudit
+{
+    /**
+     * One structured line per admin-API mutation. Field NAMES only, except
+     * enabled/email_domains whose values are operationally interesting.
+     */
+    public static function log(Request $request, string $action, array $context = []): void
+    {
+        Log::info('admin api: '.$action, [
+            'acting_admin' => $request->header('X-Acting-Admin'),
+            'method' => $request->method(),
+            'path' => $request->path(),
+        ] + $context);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.7",
         "fakerphp/faker": "^1.9.1",
+        "laravel/dusk": "^8.6",
         "laravel/pint": "^1.29",
         "laravel/sail": "^1.8",
         "mockery/mockery": "^1.4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3170075c221184ec65a5c0162d971354",
+    "content-hash": "3c933f17a842fcfc307cbbc494d692e0",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -7096,6 +7096,80 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "laravel/dusk",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/dusk.git",
+                "reference": "e7fd48762c6a82ad2cd311db07587aa2a97ce143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/dusk/zipball/e7fd48762c6a82ad2cd311db07587aa2a97ce143",
+                "reference": "e7fd48762c6a82ad2cd311db07587aa2a97ce143",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^7.5",
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "php-webdriver/webdriver": "^1.15.2",
+                "symfony/console": "^6.2|^7.0|^8.0",
+                "symfony/finder": "^6.2|^7.0|^8.0",
+                "symfony/process": "^6.2|^7.0|^8.0",
+                "vlucas/phpdotenv": "^5.2"
+            },
+            "require-dev": {
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench-core": "^8.19|^9.17|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0.1",
+                "psy/psysh": "^0.11.12|^0.12",
+                "symfony/yaml": "^6.2|^7.0|^8.0"
+            },
+            "suggest": {
+                "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Dusk\\DuskServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Dusk\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Dusk provides simple end-to-end testing and browser automation.",
+            "keywords": [
+                "laravel",
+                "testing",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/dusk/issues",
+                "source": "https://github.com/laravel/dusk/tree/v8.6.0"
+            },
+            "time": "2026-04-15T14:50:40+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.29.3",
             "source": {
@@ -7582,6 +7656,72 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-webdriver/webdriver",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-webdriver/php-webdriver.git",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/ac0662863aa120b4f645869f584013e4c4dba46a",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^7.3 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.12",
+                "symfony/process": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "replace": {
+                "facebook/webdriver": "*"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.20.0",
+                "ondram/ci-detector": "^4.0",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^9.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-simplexml": "For Firefox profile creation"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Exception/TimeoutException.php"
+                ],
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
+            "homepage": "https://github.com/php-webdriver/php-webdriver",
+            "keywords": [
+                "Chromedriver",
+                "geckodriver",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.16.0"
+            },
+            "time": "2025-12-28T23:57:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    // Static service token for the admin API (shared with website_root/admin).
+    // Unset = admin API disabled (middleware returns 503, fail-closed).
+    'api_token' => env('ADMIN_API_TOKEN'),
+];

--- a/config/database.php
+++ b/config/database.php
@@ -106,7 +106,11 @@ return [
     |
     */
 
-    'migrations' => 'migrations',
+    // Not the default 'migrations': the production database is shared with
+    // other Laravel apps (e.g. the techSupport sub-app) whose history lives
+    // in `migrations`. A dedicated table keeps this app's migrate runs from
+    // reading or writing another app's history.
+    'migrations' => 'migrations_login',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/saml.php
+++ b/config/saml.php
@@ -13,4 +13,8 @@ return [
     // Cache store + TTL for assertion-ID replay protection
     'replay_store' => env('SAML_REPLAY_STORE', 'redis'),
     'replay_ttl' => env('SAML_REPLAY_TTL', 300),
+
+    // Admin portal SSO handoff (docs/specs/2026-07-09-admin-portal-sso.md)
+    'admin_portal_url' => env('ADMIN_PORTAL_URL', 'https://www.apexinnovations.com/admin'),
+    'admin_handoff_ttl' => env('ADMIN_HANDOFF_TTL', 60),
 ];

--- a/database/factories/DepartmentFactory.php
+++ b/database/factories/DepartmentFactory.php
@@ -9,10 +9,11 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class DepartmentFactory extends Factory
 {
     /**
-     * Realistic hospital departments. unique() guards the legacy
-     * UNIQUE(Name, OrganizationID) index when one test creates several
-     * departments; the pool must stay comfortably larger than any single
-     * test's appetite.
+     * Realistic hospital department names. definition() picks a random
+     * (non-unique) name; per-org uniqueness of department names is
+     * guaranteed only by OrganizationFactory::withDepartments(), which
+     * sequences distinct names. Bare multi-department creates against
+     * one org must pass explicit Name values.
      */
     public const NAMES = [
         'Emergency', 'Cardiology', 'ICU', 'Radiology', 'Oncology',

--- a/database/factories/DepartmentFactory.php
+++ b/database/factories/DepartmentFactory.php
@@ -28,7 +28,7 @@ class DepartmentFactory extends Factory
     public function definition(): array
     {
         return [
-            'Name' => $this->faker->unique()->randomElement(self::NAMES),
+            'Name' => $this->faker->randomElement(self::NAMES),
             'Active' => 'Y',
             'OrganizationID' => Organization::factory(),
         ];

--- a/database/factories/DepartmentFactory.php
+++ b/database/factories/DepartmentFactory.php
@@ -8,12 +8,27 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 
 class DepartmentFactory extends Factory
 {
+    /**
+     * Realistic hospital departments. unique() guards the legacy
+     * UNIQUE(Name, OrganizationID) index when one test creates several
+     * departments; the pool must stay comfortably larger than any single
+     * test's appetite.
+     */
+    public const NAMES = [
+        'Emergency', 'Cardiology', 'ICU', 'Radiology', 'Oncology',
+        'Pediatrics', 'Surgery', 'Labor & Delivery', 'Neurology',
+        'Orthopedics', 'Pharmacy', 'Laboratory', 'Respiratory Therapy',
+        'Physical Therapy', 'Behavioral Health', 'Infection Control',
+        'Case Management', 'Wound Care', 'Cath Lab', 'Dialysis',
+        'Endoscopy', 'Anesthesiology', 'NICU', 'Telemetry',
+    ];
+
     protected $model = Department::class;
 
     public function definition(): array
     {
         return [
-            'Name' => $this->faker->unique()->word().' Department',
+            'Name' => $this->faker->unique()->randomElement(self::NAMES),
             'Active' => 'Y',
             'OrganizationID' => Organization::factory(),
         ];

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -20,7 +20,12 @@ class OrganizationFactory extends Factory
         );
 
         return [
-            'Name' => $this->faker->unique()->company(),
+            // City carries the uniqueness (Organizations.Name is globally
+            // unique); the suffix carries the healthcare flavor.
+            'Name' => $this->faker->unique()->city().' '.$this->faker->randomElement([
+                'Medical Center', 'Regional Hospital', 'Community Hospital',
+                'Memorial Hospital', 'General Hospital',
+            ]),
             'Address' => $this->faker->streetAddress(),
             'City' => $this->faker->city(),
             'PostalCode' => $this->faker->postcode(),

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use App\Models\Organization;
+use App\Models\System;
+use App\Models\SystemOrganization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\DB;
 
@@ -51,5 +53,29 @@ class OrganizationFactory extends Factory
             'PasswordComplexityUppercase' => 'Y',
             'PasswordComplexityLowercase' => 'Y',
         ]);
+    }
+
+    /**
+     * Attach the org to a system via SystemOrganizations. A string looks up a
+     * System by Name or creates it (so repeated calls share one system); no
+     * argument creates a fresh system. Resolution is deferred to afterCreating
+     * so the lookup happens at create() time, and the join row is keyed on the
+     * org — enforcing the one-system-per-org rule the DB doesn't.
+     */
+    public function forSystem(System|string|null $system = null): static
+    {
+        return $this->afterCreating(function (Organization $org) use ($system) {
+            $resolved = match (true) {
+                $system instanceof System => $system,
+                is_string($system) => System::where('Name', $system)->first()
+                    ?? System::factory()->create(['Name' => $system]),
+                default => System::factory()->create(),
+            };
+
+            SystemOrganization::updateOrCreate(
+                ['OrganizationID' => $org->ID],
+                ['SystemID' => $resolved->ID],
+            );
+        });
     }
 }

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Department;
 use App\Models\Organization;
 use App\Models\System;
 use App\Models\SystemOrganization;
@@ -77,5 +78,28 @@ class OrganizationFactory extends Factory
                 ['SystemID' => $resolved->ID],
             );
         });
+    }
+
+    /**
+     * Create departments for the org. An int picks that many distinct names
+     * from DepartmentFactory::NAMES via a sequence — deliberately bypassing
+     * faker's global unique(), so seeding many orgs can't exhaust the pool
+     * (the legacy index is only UNIQUE(Name, OrganizationID), i.e. per-org).
+     * An array uses the exact names given. Asking for more than the pool
+     * holds cycles into duplicate names and surfaces as the natural DB error.
+     */
+    public function withDepartments(int|array $departments = 3): static
+    {
+        $names = is_array($departments)
+            ? array_values($departments)
+            : collect(DepartmentFactory::NAMES)->shuffle()->take($departments)->values()->all();
+        $count = is_array($departments) ? count($departments) : $departments;
+
+        return $this->has(
+            Department::factory()
+                ->count($count)
+                ->sequence(...array_map(fn (string $name) => ['Name' => $name], $names)),
+            'departments',
+        );
     }
 }

--- a/database/factories/SamlAttributeObservationFactory.php
+++ b/database/factories/SamlAttributeObservationFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SamlAttributeObservation;
+use App\Models\SamlClient;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SamlAttributeObservationFactory extends Factory
+{
+    protected $model = SamlAttributeObservation::class;
+
+    public function definition(): array
+    {
+        return [
+            'saml_client_id' => SamlClient::factory(),
+            'name' => $this->faker->unique()->word(),
+            'first_seen_at' => now(),
+            'last_seen_at' => now(),
+            'observation_count' => 1,
+        ];
+    }
+}

--- a/database/factories/SamlClientFactory.php
+++ b/database/factories/SamlClientFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Organization;
 use App\Models\SamlClient;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -22,7 +23,7 @@ class SamlClientFactory extends Factory
             'idp_sso_url' => 'https://idp.example.com/'.Str::slug($name).'/sso',
             'idp_certificate' => 'MIIC-placeholder-not-a-real-cert',
             'owner_type' => 'organization',
-            'owner_id' => 1,
+            'owner_id' => Organization::factory(),
             'department_id' => null,
             'jit_enabled' => true,
             'admin_portal' => false,

--- a/database/factories/SamlClientFactory.php
+++ b/database/factories/SamlClientFactory.php
@@ -24,6 +24,7 @@ class SamlClientFactory extends Factory
             'organization_id' => 1,
             'department_id' => null,
             'jit_enabled' => true,
+            'admin_portal' => false,
             'attribute_map' => [
                 'email' => 'email',
                 'first_name' => 'firstName',
@@ -31,5 +32,11 @@ class SamlClientFactory extends Factory
             ],
             'email_domains' => [],
         ];
+    }
+
+    /** A client asserting Employee (admin portal) identities. */
+    public function adminPortal(): static
+    {
+        return $this->state(fn () => ['admin_portal' => true]);
     }
 }

--- a/database/factories/SamlClientFactory.php
+++ b/database/factories/SamlClientFactory.php
@@ -21,7 +21,8 @@ class SamlClientFactory extends Factory
             'idp_entity_id' => 'https://idp.example.com/'.Str::slug($name),
             'idp_sso_url' => 'https://idp.example.com/'.Str::slug($name).'/sso',
             'idp_certificate' => 'MIIC-placeholder-not-a-real-cert',
-            'organization_id' => 1,
+            'owner_type' => 'organization',
+            'owner_id' => 1,
             'department_id' => null,
             'jit_enabled' => true,
             'admin_portal' => false,
@@ -38,5 +39,11 @@ class SamlClientFactory extends Factory
     public function adminPortal(): static
     {
         return $this->state(fn () => ['admin_portal' => true]);
+    }
+
+    /** Owned by a system: spans that system's organizations. */
+    public function forSystem(int $systemId): static
+    {
+        return $this->state(fn () => ['owner_type' => 'system', 'owner_id' => $systemId]);
     }
 }

--- a/database/factories/SamlClientFactory.php
+++ b/database/factories/SamlClientFactory.php
@@ -33,6 +33,7 @@ class SamlClientFactory extends Factory
                 'last_name' => 'lastName',
             ],
             'email_domains' => [],
+            'known_attributes' => [],
         ];
     }
 

--- a/database/factories/SamlDepartmentRuleFactory.php
+++ b/database/factories/SamlDepartmentRuleFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SamlDepartmentRule;
+use App\Saml\RoutingOperator;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SamlDepartmentRuleFactory extends Factory
+{
+    protected $model = SamlDepartmentRule::class;
+
+    public function definition(): array
+    {
+        return [
+            'position' => 1,
+            'attribute' => 'department',
+            'operator' => RoutingOperator::Equals,
+            'value' => $this->faker->unique()->word(),
+            'department_name' => $this->faker->unique()->word(),
+        ];
+    }
+
+    /** The reserved match-everyone triple. */
+    public function catchAll(): static
+    {
+        return $this->state(fn () => [
+            'attribute' => '*', 'operator' => RoutingOperator::Wildcard, 'value' => '*',
+        ]);
+    }
+}

--- a/database/factories/SamlOrgRuleFactory.php
+++ b/database/factories/SamlOrgRuleFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SamlOrgRule;
+use App\Saml\RoutingOperator;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SamlOrgRuleFactory extends Factory
+{
+    protected $model = SamlOrgRule::class;
+
+    public function definition(): array
+    {
+        return [
+            'position' => 1,
+            'attribute' => 'department',
+            'operator' => RoutingOperator::Equals,
+            'value' => $this->faker->unique()->word(),
+            'organization_id' => 1,
+        ];
+    }
+
+    /** The reserved match-everyone triple. */
+    public function catchAll(): static
+    {
+        return $this->state(fn () => [
+            'attribute' => '*', 'operator' => RoutingOperator::Wildcard, 'value' => '*',
+        ]);
+    }
+}

--- a/database/factories/SsoGrantFactory.php
+++ b/database/factories/SsoGrantFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SsoGrant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SsoGrantFactory extends Factory
+{
+    protected $model = SsoGrant::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'organization_id' => 1,
+            'granted_by' => '1:Test Admin',
+        ];
+    }
+}

--- a/database/factories/SsoGrantFactory.php
+++ b/database/factories/SsoGrantFactory.php
@@ -14,7 +14,8 @@ class SsoGrantFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'organization_id' => 1,
+            'owner_type' => 'organization',
+            'owner_id' => 1,
             'granted_by' => '1:Test Admin',
         ];
     }

--- a/database/factories/SystemFactory.php
+++ b/database/factories/SystemFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Organization;
 use App\Models\System;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -15,5 +16,18 @@ class SystemFactory extends Factory
             'Name' => $this->faker->unique()->city().' Health System',
             'CreationDate' => now()->format('Y-m-d'),
         ];
+    }
+
+    /**
+     * Build the whole tree: N organizations attached through SystemOrganizations,
+     * each with departments (int count or exact names — see
+     * OrganizationFactory::withDepartments()).
+     */
+    public function withOrganizations(int $count = 2, int|array $departmentsEach = 3): static
+    {
+        return $this->has(
+            Organization::factory()->count($count)->withDepartments($departmentsEach),
+            'organizations',
+        );
     }
 }

--- a/database/factories/SystemFactory.php
+++ b/database/factories/SystemFactory.php
@@ -12,7 +12,7 @@ class SystemFactory extends Factory
     public function definition(): array
     {
         return [
-            'Name' => $this->faker->unique()->company().' System',
+            'Name' => $this->faker->unique()->city().' Health System',
             'CreationDate' => now()->format('Y-m-d'),
         ];
     }

--- a/database/migrations/2026_07_07_100000_create_sso_grants_table.php
+++ b/database/migrations/2026_07_07_100000_create_sso_grants_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sso_grants', function (Blueprint $table) {
+            $table->id();
+            $table->integer('user_id');           // Users.ID (legacy schema, no FK constraint)
+            $table->integer('organization_id');
+            $table->string('granted_by');         // acting admin identity (Employees world, no FK)
+            $table->timestamps();
+            $table->unique(['user_id', 'organization_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sso_grants');
+    }
+};

--- a/database/migrations/2026_07_09_100000_add_admin_portal_to_saml_clients_table.php
+++ b/database/migrations/2026_07_09_100000_add_admin_portal_to_saml_clients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('saml_clients', function (Blueprint $table) {
+            // Marks a client that asserts Employee (admin portal) identities
+            // rather than Users; see docs/specs/2026-07-09-admin-portal-sso.md
+            $table->boolean('admin_portal')->default(false)->after('jit_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->dropColumn('admin_portal');
+        });
+    }
+};

--- a/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
+++ b/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * A client (and its SSO-manager grant list) is owned by an organization
+     * or a system (docs/specs/2026-07-10-client-ownership.md). Nothing using
+     * organization_id has deployed, so this renames rather than shims.
+     */
+    public function up(): void
+    {
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->string('owner_type', 20)->nullable()->after('enabled');
+            $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
+        });
+
+        DB::table('saml_clients')->update([
+            'owner_type' => 'organization',
+            'owner_id' => DB::raw('organization_id'),
+        ]);
+
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->string('owner_type', 20)->nullable(false)->change();
+            $table->unsignedInteger('owner_id')->nullable(false)->change();
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('sso_grants', function (Blueprint $table) {
+            $table->string('owner_type', 20)->nullable()->after('user_id');
+            $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
+        });
+
+        DB::table('sso_grants')->update([
+            'owner_type' => 'organization',
+            'owner_id' => DB::raw('organization_id'),
+        ]);
+
+        Schema::table('sso_grants', function (Blueprint $table) {
+            $table->string('owner_type', 20)->nullable(false)->change();
+            $table->unsignedInteger('owner_id')->nullable(false)->change();
+            $table->dropUnique(['user_id', 'organization_id']);
+            $table->unique(['user_id', 'owner_type', 'owner_id']);
+            $table->dropColumn('organization_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sso_grants', function (Blueprint $table) {
+            $table->integer('organization_id')->nullable()->after('user_id');
+        });
+        DB::table('sso_grants')->where('owner_type', 'organization')->update(['organization_id' => DB::raw('owner_id')]);
+        DB::table('sso_grants')->where('owner_type', '!=', 'organization')->delete();
+        Schema::table('sso_grants', function (Blueprint $table) {
+            $table->integer('organization_id')->nullable(false)->change();
+            $table->dropUnique(['user_id', 'owner_type', 'owner_id']);
+            $table->unique(['user_id', 'organization_id']);
+            $table->dropColumn(['owner_type', 'owner_id']);
+        });
+
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->integer('organization_id')->nullable()->after('enabled');
+        });
+        DB::table('saml_clients')->where('owner_type', 'organization')->update(['organization_id' => DB::raw('owner_id')]);
+        DB::table('saml_clients')->where('owner_type', '!=', 'organization')->delete();
+        Schema::table('saml_clients', function (Blueprint $table) {
+            $table->integer('organization_id')->nullable(false)->change();
+            $table->dropColumn(['owner_type', 'owner_id']);
+        });
+    }
+};

--- a/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
+++ b/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
@@ -14,39 +14,43 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('saml_clients', function (Blueprint $table) {
-            $table->string('owner_type', 20)->nullable()->after('enabled');
-            $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
-        });
+        if (! Schema::hasColumn('saml_clients', 'owner_type')) {
+            Schema::table('saml_clients', function (Blueprint $table) {
+                $table->string('owner_type', 20)->nullable()->after('enabled');
+                $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
+            });
 
-        DB::table('saml_clients')->update([
-            'owner_type' => 'organization',
-            'owner_id' => DB::raw('organization_id'),
-        ]);
+            DB::table('saml_clients')->update([
+                'owner_type' => 'organization',
+                'owner_id' => DB::raw('organization_id'),
+            ]);
 
-        Schema::table('saml_clients', function (Blueprint $table) {
-            $table->string('owner_type', 20)->nullable(false)->change();
-            $table->unsignedInteger('owner_id')->nullable(false)->change();
-            $table->dropColumn('organization_id');
-        });
+            Schema::table('saml_clients', function (Blueprint $table) {
+                $table->string('owner_type', 20)->nullable(false)->change();
+                $table->unsignedInteger('owner_id')->nullable(false)->change();
+                $table->dropColumn('organization_id');
+            });
+        }
 
-        Schema::table('sso_grants', function (Blueprint $table) {
-            $table->string('owner_type', 20)->nullable()->after('user_id');
-            $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
-        });
+        if (! Schema::hasColumn('sso_grants', 'owner_type')) {
+            Schema::table('sso_grants', function (Blueprint $table) {
+                $table->string('owner_type', 20)->nullable()->after('user_id');
+                $table->unsignedInteger('owner_id')->nullable()->after('owner_type');
+            });
 
-        DB::table('sso_grants')->update([
-            'owner_type' => 'organization',
-            'owner_id' => DB::raw('organization_id'),
-        ]);
+            DB::table('sso_grants')->update([
+                'owner_type' => 'organization',
+                'owner_id' => DB::raw('organization_id'),
+            ]);
 
-        Schema::table('sso_grants', function (Blueprint $table) {
-            $table->string('owner_type', 20)->nullable(false)->change();
-            $table->unsignedInteger('owner_id')->nullable(false)->change();
-            $table->dropUnique(['user_id', 'organization_id']);
-            $table->unique(['user_id', 'owner_type', 'owner_id']);
-            $table->dropColumn('organization_id');
-        });
+            Schema::table('sso_grants', function (Blueprint $table) {
+                $table->string('owner_type', 20)->nullable(false)->change();
+                $table->unsignedInteger('owner_id')->nullable(false)->change();
+                $table->dropUnique(['user_id', 'organization_id']);
+                $table->unique(['user_id', 'owner_type', 'owner_id']);
+                $table->dropColumn('organization_id');
+            });
+        }
     }
 
     public function down(): void

--- a/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
+++ b/database/migrations/2026_07_10_100000_add_owner_to_saml_clients_and_sso_grants.php
@@ -55,6 +55,7 @@ return new class extends Migration
             $table->integer('organization_id')->nullable()->after('user_id');
         });
         DB::table('sso_grants')->where('owner_type', 'organization')->update(['organization_id' => DB::raw('owner_id')]);
+        // Rollback drops system-owned rows by design — they have no organization_id to restore.
         DB::table('sso_grants')->where('owner_type', '!=', 'organization')->delete();
         Schema::table('sso_grants', function (Blueprint $table) {
             $table->integer('organization_id')->nullable(false)->change();
@@ -67,6 +68,7 @@ return new class extends Migration
             $table->integer('organization_id')->nullable()->after('enabled');
         });
         DB::table('saml_clients')->where('owner_type', 'organization')->update(['organization_id' => DB::raw('owner_id')]);
+        // Rollback drops system-owned rows by design — they have no organization_id to restore.
         DB::table('saml_clients')->where('owner_type', '!=', 'organization')->delete();
         Schema::table('saml_clients', function (Blueprint $table) {
             $table->integer('organization_id')->nullable(false)->change();

--- a/database/migrations/2026_07_11_100000_create_saml_routing_rule_tables.php
+++ b/database/migrations/2026_07_11_100000_create_saml_routing_rule_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Two ordered rule lists per client (docs/specs/2026-07-10-attribute-routing.md):
+     * org rules place users in an organization (system-owned clients only),
+     * department rules place them in a department BY NAME within the resolved
+     * org — name-targeting is what lets one rule set serve every identically
+     * structured org in a hospital system.
+     */
+    public function up(): void
+    {
+        Schema::create('saml_org_rules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('saml_client_id');
+            $table->unsignedInteger('position');
+            $table->string('attribute');
+            $table->string('operator', 20);
+            $table->string('value');
+            $table->integer('organization_id');
+            $table->timestamps();
+            $table->unique(['saml_client_id', 'position']);
+        });
+
+        Schema::create('saml_department_rules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('saml_client_id');
+            $table->unsignedInteger('position');
+            $table->string('attribute');
+            $table->string('operator', 20);
+            $table->string('value');
+            $table->string('department_name');
+            $table->timestamps();
+            $table->unique(['saml_client_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saml_department_rules');
+        Schema::dropIfExists('saml_org_rules');
+    }
+};

--- a/database/migrations/2026_07_11_120000_add_known_attributes_and_observations.php
+++ b/database/migrations/2026_07_11_120000_add_known_attributes_and_observations.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * known_attributes: the fast-read set the routing-rule-editor dropdown
+     * consumes. saml_attribute_observations: the names-only capture history
+     * that backs it (NEVER stores attribute values — that's PHI). Spec:
+     * docs/specs/2026-07-11-known-attributes.md
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('saml_clients', 'known_attributes')) {
+            Schema::table('saml_clients', function (Blueprint $table) {
+                $table->json('known_attributes')->nullable()->after('attribute_map');
+            });
+        }
+
+        Schema::create('saml_attribute_observations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('saml_client_id');
+            $table->string('name');
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->unsignedInteger('observation_count')->default(0);
+            $table->timestamps();
+            $table->unique(['saml_client_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saml_attribute_observations');
+        if (Schema::hasColumn('saml_clients', 'known_attributes')) {
+            Schema::table('saml_clients', function (Blueprint $table) {
+                $table->dropColumn('known_attributes');
+            });
+        }
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1693,7 +1693,7 @@ CREATE TABLE `MCSUserData` (
   KEY `DepartmentName` (`DepartmentName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Table stores all MCS user data for monthly data report';
 
-CREATE TABLE `migrations` (
+CREATE TABLE `migrations_login` (
   `migration` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
   `batch` int NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,8 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(ReferenceDataSeeder::class);
         $this->call(LocalSamlClientSeeder::class);
+        $this->call(EventTypesSeeder::class);
+        $this->call(LocalEmployeeSeeder::class);
 
         // Known local login: dev@example.test / password.
         // Pinned to seeded Department 1 — letting the factory mint its own

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,5 +30,17 @@ class DatabaseSeeder extends Seeder
             'LastName' => 'User',
             'DepartmentID' => 1,
         ]);
+
+        // Known local login belonging to the SSO Organization (933) / SSO
+        // Department (3) — the local-idp SAML client's org. Used for
+        // exercising the admin portal's SSO grants panel, which requires
+        // the granted user's department to belong to the client's
+        // organization (SsoGrantController::replace).
+        User::factory()->create([
+            'Login' => 'dev-sso@example.test',
+            'FirstName' => 'Dev',
+            'LastName' => 'SsoUser',
+            'DepartmentID' => 3,
+        ]);
     }
 }

--- a/database/seeders/EventTypesSeeder.php
+++ b/database/seeders/EventTypesSeeder.php
@@ -12,6 +12,13 @@ class EventTypesSeeder extends Seeder
      */
     public function run(): void
     {
+        // Dev fixture; must never touch a shared database. `testing` is
+        // included because phpunit runs against a disposable local MySQL
+        // database (apex_login_test), not the shared one.
+        if (! app()->environment(['local', 'testing'])) {
+            return;
+        }
+
         DB::table('EventTypes')->insertOrIgnore([
             ['ID' => 1, 'Description' => 'Admin Logged IN'],
             ['ID' => 2, 'Description' => 'Admin Logged OUT'],

--- a/database/seeders/EventTypesSeeder.php
+++ b/database/seeders/EventTypesSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class EventTypesSeeder extends Seeder
+{
+    /**
+     * Seed the EventTypes table used by the admin portal for audit logging.
+     */
+    public function run(): void
+    {
+        DB::table('EventTypes')->insertOrIgnore([
+            ['ID' => 1, 'Description' => 'Admin Logged IN'],
+            ['ID' => 2, 'Description' => 'Admin Logged OUT'],
+        ]);
+    }
+}

--- a/database/seeders/LocalEmployeeSeeder.php
+++ b/database/seeders/LocalEmployeeSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class LocalEmployeeSeeder extends Seeder
+{
+    /**
+     * Known local admin for the legacy portal (website_root/admin):
+     * dev.admin / password. The portal hashes with md5('p6^8&'.$pw)
+     * (website_admin/doLogon.php) and force-resets passwords older than
+     * 90 days (HEADER.php), hence the fresh PasswordLastChanged.
+     */
+    public function run(): void
+    {
+        DB::table('Employees')->updateOrInsert(
+            ['Email' => 'dev.admin@apexinnovations.com'],
+            [
+                'FirstName' => 'Dev',
+                'LastName' => 'Admin',
+                'Password' => md5('p6^8&password'),
+                'Active' => 'Y',
+                'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+            ],
+        );
+    }
+}

--- a/database/seeders/LocalEmployeeSeeder.php
+++ b/database/seeders/LocalEmployeeSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class LocalEmployeeSeeder extends Seeder
 {
@@ -28,6 +29,19 @@ class LocalEmployeeSeeder extends Seeder
                 'FirstName' => 'Dev',
                 'LastName' => 'Admin',
                 'Password' => md5('p6^8&password'),
+                'Active' => 'Y',
+                'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+            ],
+        );
+
+        // The mock IdP's static user1 assertion (email user1@example.com),
+        // seeded as an active Employee so admin-portal SSO can match it.
+        DB::table('Employees')->updateOrInsert(
+            ['Email' => 'user1@example.com'],
+            [
+                'FirstName' => 'Mock',
+                'LastName' => 'IdPAdmin',
+                'Password' => md5('p6^8&'.Str::random(32)), // never used; SSO only
                 'Active' => 'Y',
                 'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
             ],

--- a/database/seeders/LocalEmployeeSeeder.php
+++ b/database/seeders/LocalEmployeeSeeder.php
@@ -15,6 +15,13 @@ class LocalEmployeeSeeder extends Seeder
      */
     public function run(): void
     {
+        // Dev fixture; must never touch a shared database. `testing` is
+        // included because phpunit runs against a disposable local MySQL
+        // database (apex_login_test), not the shared one.
+        if (! app()->environment(['local', 'testing'])) {
+            return;
+        }
+
         DB::table('Employees')->updateOrInsert(
             ['Email' => 'dev.admin@apexinnovations.com'],
             [

--- a/database/seeders/LocalHierarchySeeder.php
+++ b/database/seeders/LocalHierarchySeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Organization;
+use App\Models\System;
+use Illuminate\Database\Seeder;
+
+/**
+ * Local-dev hierarchy for browser testing: one system with three orgs of
+ * four departments each, plus a standalone org (no system) with three —
+ * the no-system shape exists in production data and must stay exercised.
+ * Guarded by name so re-running never duplicates.
+ *
+ *   php artisan db:seed --class=LocalHierarchySeeder
+ */
+class LocalHierarchySeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (! System::where('Name', 'Memorial Health System')->exists()) {
+            System::factory()
+                ->withOrganizations(3, departmentsEach: 4)
+                ->create(['Name' => 'Memorial Health System']);
+        }
+
+        if (! Organization::where('Name', 'Standalone Community Hospital')->exists()) {
+            Organization::factory()
+                ->withDepartments(3)
+                ->create(['Name' => 'Standalone Community Hospital']);
+        }
+    }
+}

--- a/database/seeders/LocalSamlClientSeeder.php
+++ b/database/seeders/LocalSamlClientSeeder.php
@@ -34,5 +34,23 @@ class LocalSamlClientSeeder extends Seeder
             ],
             'email_domains' => ['example.com'],
         ]);
+
+        // Local mock IdP for the *admin portal* SSO flow (second container,
+        // mock-idp-admin, because the image only supports one SP ACS URL).
+        // user1@example.com is seeded as an Employee by LocalEmployeeSeeder.
+        SamlClient::updateOrCreate(['slug' => 'local-admin-idp'], [
+            'name' => 'Local Mock IdP (Admin Portal)',
+            'enabled' => false,
+            'admin_portal' => true,
+            'idp_entity_id' => 'pending',
+            'idp_sso_url' => 'pending',
+            'idp_certificate' => 'pending',
+            'organization_id' => 933,
+            'department_id' => null,
+            'jit_enabled' => false,
+            'attribute_map' => [
+                'email' => 'email',
+            ],
+        ]);
     }
 }

--- a/database/seeders/LocalSamlClientSeeder.php
+++ b/database/seeders/LocalSamlClientSeeder.php
@@ -26,7 +26,8 @@ class LocalSamlClientSeeder extends Seeder
             'idp_entity_id' => 'pending',
             'idp_sso_url' => 'pending',
             'idp_certificate' => 'pending',
-            'organization_id' => 933,
+            'owner_type' => 'organization',
+            'owner_id' => 933,
             'department_id' => null,
             'jit_enabled' => true,
             'attribute_map' => [
@@ -45,7 +46,8 @@ class LocalSamlClientSeeder extends Seeder
             'idp_entity_id' => 'pending',
             'idp_sso_url' => 'pending',
             'idp_certificate' => 'pending',
-            'organization_id' => 933,
+            'owner_type' => 'organization',
+            'owner_id' => 933,
             'department_id' => null,
             'jit_enabled' => false,
             'attribute_map' => [

--- a/database/seeders/ReferenceDataSeeder.php
+++ b/database/seeders/ReferenceDataSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Department;
 use App\Models\Organization;
+use App\Models\System;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -38,6 +39,14 @@ class ReferenceDataSeeder extends Seeder
         Department::factory()->create(['ID' => 1, 'OrganizationID' => 1, 'Name' => 'General']);
         Department::factory()->create(['ID' => 2, 'OrganizationID' => 2, 'Name' => 'Strict Department']);
         Department::factory()->create(['ID' => 3, 'OrganizationID' => 933, 'Name' => 'SSO Department']);
+
+        // Local system spanning orgs 1 and 2 so system-owned clients are
+        // testable locally; org 933 stays system-less (degenerate case).
+        System::factory()->create(['ID' => 1, 'Name' => 'Local Health System']);
+        DB::table('SystemOrganizations')->insert([
+            ['SystemID' => 1, 'OrganizationID' => 1],
+            ['SystemID' => 1, 'OrganizationID' => 2],
+        ]);
 
         DB::table('Credentials')->insert([
             ['ID' => 1, 'Name' => 'RN'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,16 @@ services:
             SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: 'http://localhost:8090/saml/local-idp/acs'
         networks:
             - sail
+    mock-idp-admin:
+        image: 'kristophjunge/test-saml-idp'
+        ports:
+            - '${MOCK_IDP_ADMIN_PORT:-8093}:8080'
+        environment:
+            SIMPLESAMLPHP_SP_ENTITY_ID: '${APP_URL:-http://localhost:8090}/saml/metadata'
+            SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: 'http://localhost:8090/saml/local-admin-idp/acs'
+            SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: 'http://localhost:8090/saml/local-admin-idp/acs'
+        networks:
+            - sail
     mysql:
         image: 'mysql:8.0'
         # Legacy production MySQL runs non-strict (no ONLY_FULL_GROUP_BY / STRICT_TRANS_TABLES)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
             - '.:/var/www/html'
         networks:
             - sail
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
         depends_on:
             mysql:
                 condition: service_healthy
@@ -27,6 +29,18 @@ services:
         image: apex-website-local/app
         ports:
             - '${WEBSITE_PORT:-8091}:80'
+            # Also publish on bare :80. website_admin/SESSIONCONFIG.php builds
+            # the admin session cookie's Domain from $_SERVER['HTTP_HOST'] when
+            # the host matches /local/i, and a port in that value (e.g.
+            # "localhost:8091") produces an invalid Domain attribute that
+            # browsers silently drop. Dusk must hit the admin portal via
+            # http://localhost/admin (no port) for the session cookie to
+            # persist; :8091 is unaffected and remains the documented URL
+            # for the rest of the site (MyCurriculum.php etc).
+            # NOTE: the login service defaults to '${APP_PORT:-80}:80' — APP_PORT
+            # and WEBSITE_ADMIN_PORT must never both fall back to :80 at once.
+            # The documented env (make setup) always sets APP_PORT=8090.
+            - '${WEBSITE_ADMIN_PORT:-80}:80'
         volumes:
             - '../website_root:/var/www/html'
             # Submodules of website_root that exist as sibling checkouts
@@ -85,6 +99,13 @@ services:
             - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
         networks:
             - sail
+    selenium:
+        image: 'selenium/standalone-chrome'
+        # Host networking (Linux): Chrome inside must reach the apps as
+        # http://localhost:809x — the admin session cookie is Secure+SameSite=None
+        # and Chrome only accepts that over http on localhost.
+        network_mode: host
+        shm_size: '2gb'
 networks:
     sail:
         driver: bridge

--- a/docker/website.env.dev
+++ b/docker/website.env.dev
@@ -32,3 +32,10 @@ SES_KEY=
 SES_SECRET=
 
 LOGIN_URL=http://localhost:8090
+
+# Admin API bridge (website_admin/doSSOClients.php -> login app's admin API).
+# LOGIN_API_URL uses the login service's container-network name (both
+# containers share the "sail" docker-compose network); LOGIN_ADMIN_API_TOKEN
+# must match ADMIN_API_TOKEN in login/.env.dev.
+LOGIN_API_URL=http://login
+LOGIN_ADMIN_API_TOKEN=local-dev-admin-token

--- a/docker/website.env.dev
+++ b/docker/website.env.dev
@@ -39,3 +39,6 @@ LOGIN_URL=http://localhost:8090
 # must match ADMIN_API_TOKEN in login/.env.dev.
 LOGIN_API_URL=http://login
 LOGIN_ADMIN_API_TOKEN=local-dev-admin-token
+
+# Slug of the admin-portal SAML client on the login app (apex-admin in prod).
+LOGIN_SSO_CLIENT=local-admin-idp

--- a/docs/specs/2026-07-07-sso-admin-tools.md
+++ b/docs/specs/2026-07-07-sso-admin-tools.md
@@ -1,0 +1,136 @@
+# SSO Admin Tools — Design
+
+Milestone 4 of the SSO contract: administrative tools for Apex personnel to configure
+client SSO settings. The admin experience lives where Apex admins already work — the
+legacy site's admin portal (`website_root/admin`) — backed by a JSON API on the login
+application so `SamlClientManager` remains the single validated write path shared with
+the `saml:client` CLI.
+
+Two codebases: the API in this repo, the screens in `website_root` (sibling checkout).
+
+## Trust model
+
+The admin portal authenticates its own users against the Employees schema — a separate
+auth world from the shared `Users` session, with essentially flat RBAC (portal access ≈
+full access). The login app does not attempt to validate that world. Instead:
+
+- **A static service token authorizes.** `ADMIN_API_TOKEN` in both apps' env (the same
+  way the session key is already shared). The browser never sees it: admin pages talk to
+  a portal-side action script, which calls the login API server-to-server.
+- **`X-Acting-Admin` attributes.** Every mutating request carries the acting admin's
+  employee identity in this header; the API requires it (400 if absent on mutations) and
+  writes it to the audit log. It grants nothing — the token does that.
+
+Rejected alternatives: browser-direct API calls (would require the login app to validate
+Employees auth, or expose the token); an admin UI inside the login app (puts SSO admin in
+a different place from every other admin task).
+
+## API surface (login app)
+
+All under `/api/admin`, JSON in/out, guarded by the `admin.api` middleware:
+
+```
+GET    /saml-clients                      list: name, slug, enabled, jit, org/dept,
+                                          domains, cert expires_at + expiring flag
+GET    /saml-clients/{slug}               full detail incl. ACS/metadata URLs,
+                                          attribute map, grants count
+POST   /saml-clients                      create (name, slug?, organization_id,
+                                          department_id?, jit_enabled?, email_domains?)
+PATCH  /saml-clients/{slug}               partial update of the above + attribute_map
+POST   /saml-clients/{slug}/idp-metadata  body: {xml} — runs updateFromIdpMetadata
+POST   /saml-clients/{slug}/enable
+POST   /saml-clients/{slug}/disable
+GET    /saml-clients/{slug}/grants        list grants for the client's organization
+PUT    /saml-clients/{slug}/grants        replace grants (list of Users.Login values)
+```
+
+Controllers are transport only: translate HTTP ↔ `SamlClientManager` (and the grants
+model). No validation logic in controllers — `ValidationException` surfaces as a
+standard Laravel 422 error bag the portal JS renders as field errors. Unknown slug → 404.
+
+## Middleware: `admin.api`
+
+- `Authorization: Bearer <token>` compared to `config('admin.api_token')` with
+  `hash_equals`; 401 on mismatch.
+- If the env var is unset: 503 + a logged error — a misconfigured deploy fails loud and
+  closed, never open.
+- Mutating verbs require `X-Acting-Admin` (non-empty string); 400 otherwise.
+- No rate limiting: server-to-server behind a shared secret.
+
+Every mutation logs one structured line: acting admin, method+path, slug, and the changed
+field *names* (values only for `enabled` and `email_domains`, which are the operationally
+interesting ones).
+
+## Grants model (designed now, consumed later)
+
+Approved direction: admins may delegate SSO control to specific customer users, scoped to
+their organization. Milestone 4 ships the model and admin-side management; the end-user
+experience that *consumes* grants ("manage my org's SSO" in the login app) is explicitly
+future work.
+
+```
+sso_grants
+  id               bigint PK
+  user_id          int            Users.ID
+  organization_id  int
+  granted_by       string         acting admin identity (Employees world — no FK)
+  created_at / updated_at
+  unique (user_id, organization_id)
+```
+
+API validation: the user exists and belongs to the organization (via Department →
+Organization). Flat by design — no roles or scopes — matching the portal's flat RBAC.
+
+## Admin screens (website_root/admin)
+
+One page + one action script, written in the portal's existing house style (Admin.inc
+bootstrap, jQuery, `ajax/`-style action endpoint):
+
+- **Clients table**: name, slug, enabled, domains, cert expiry with an EXPIRING badge
+  (30-day window, same as the CLI).
+- **Create/edit form**: name, slug (create only), organization, default department, JIT
+  toggle, domains (comma-separated), attribute-map fields.
+- **IdP metadata**: paste-in textarea (file upload optional if the house pattern makes it
+  cheap) → the metadata endpoint; shows resulting entity ID / SSO URL / cert expiry.
+- **Enable/disable** buttons with confirmation.
+- **Grants panel** (detail view): list grants, add by `Users.Login` lookup constrained to
+  the client's organization, remove.
+
+The action script holds the bearer token (from the portal's env) and the acting-admin
+identity from the portal's session; it proxies JSON to the login API and passes 422 error
+bags through for inline field rendering.
+
+## Testing
+
+- **Login app (feature tests)**: middleware matrix (no token, wrong token, env unset →
+  503, missing X-Acting-Admin on mutation → 400); every endpoint's happy path,
+  validation failure, uniqueness conflict, unknown-slug 404; grants list/replace incl.
+  org-membership validation. Existing CLI tests stay green untouched — evidence the
+  manager remains the shared path.
+- **E2E — Laravel Dusk**: browser tests in this repo drive the real admin page across
+  the compose network (`http://website/admin/...`) — table rendering, create/edit with
+  inline 422 errors, metadata upload, enable/disable, grants panel. Setup: a
+  `selenium/standalone-chrome` service in docker-compose + `DUSK_DRIVER_URL`. Dusk sees
+  the actual jQuery behavior a curl script cannot. Local-only gate (like `make e2e`);
+  CI does not run the compose environment.
+  - **Plan-time checkpoint**: the tests must log into the portal, so the local website
+    container needs a seeded Employees-schema admin account (or known dev credentials).
+    Confirm this is seedable before committing to the Dusk path in the plan.
+- The legacy repo has no unit-test harness; no attempt to add one in this milestone.
+
+## Budget shape (15h)
+
+API + middleware + grants ≈ 7h; admin page + action script ≈ 5h; E2E + docs ≈ 2h;
+slack ≈ 1h. Feasible because the API adds transport, not validation — all rules already
+live in `SamlClientManager`.
+
+## Out of scope
+
+- End-user-facing grant consumption (a granted user managing their org's SSO) — future
+  milestone; the grants table and admin management exist so it can be added without
+  rework.
+- Any RBAC beyond portal-access + token (matches the portal's reality).
+- Attribute-based routing configuration (milestone 5).
+- Modernizing or testing the legacy admin portal beyond the one new page.
+- Refactoring milestone 3's shell-script E2E (saml-login.sh, session-handoff.sh) onto
+  Dusk — endorsed as a follow-up once Dusk exists, not in this budget.

--- a/docs/specs/2026-07-07-sso-admin-tools.md
+++ b/docs/specs/2026-07-07-sso-admin-tools.md
@@ -58,8 +58,8 @@ standard Laravel 422 error bag the portal JS renders as field errors. Unknown sl
 - No rate limiting: server-to-server behind a shared secret.
 
 Every mutation logs one structured line: acting admin, method+path, slug, and the changed
-field *names* (values only for `enabled` and `email_domains`, which are the operationally
-interesting ones).
+field *names* (values only for `enabled`, `email_domains`, and grant logins, which are the
+operationally interesting ones).
 
 ## Grants model (designed now, consumed later)
 

--- a/docs/specs/2026-07-07-sso-admin-ux.md
+++ b/docs/specs/2026-07-07-sso-admin-ux.md
@@ -1,0 +1,114 @@
+# SSO Admin UX — Design
+
+Follow-on to milestone 4 (SSO admin tools), deliberately beyond the fixed-bid hours:
+make the SSO Clients admin experience enjoyable rather than merely functional. Admins
+should never have to remember an Organization ID, a Department ID, or a user's exact
+login — the relationships already exist; the UI should walk them.
+
+Two codebases, same trust model as milestone 4: the browser talks only to the portal's
+`doSSOClients.php` bridge; the bridge talks to the login app's admin API with the
+service token.
+
+## Page architecture
+
+`website_admin/SSOClients.php` keeps its house shell — `$PageName`, `HEADER.php`, the
+`$_SESSION['AdminID']` gate, `FOOTER.php` — but its authorized body reduces to
+`<div id="ssoClientsVue"></div>`.
+
+The experience is a Vue 2 + Element UI component, `SSOClientsApp.vue`, in the portal's
+existing `admincomponents` app, registered in `main.js`'s `renderVue()` mount list —
+the same pattern `Departments.php` and `Organizations.php` already use. Element UI is
+already bundled and loaded on every admin page via `FOOTER.php`.
+
+The current jQuery implementation is retired wholesale, not maintained in parallel.
+This also retires the string-concatenation escaping problem class: Vue text
+interpolation escapes by default.
+
+## Lookup endpoints (login app)
+
+Three read-only endpoints behind the existing `admin.api` middleware, mirroring the
+CLI wizard's queries (`SamlClientCommand::wizardOrganizationOptions/DepartmentOptions`):
+
+```
+GET /api/admin/organizations?q=          -> {data: [{id, name}]}          limit 25, Name like %q%, ordered by Name
+GET /api/admin/organizations/{id}/departments
+                                         -> {data: [{id, name}]}          Active='Y', ordered by Name
+GET /api/admin/saml-clients/{slug}/users?q=
+                                         -> {data: [{login, first_name,
+                                             last_name, department}]}     limit 25, scoped to the client's
+                                                                          organization via Department join;
+                                                                          q matches Login or First/LastName
+```
+
+GETs carry no `X-Acting-Admin` requirement (reads are not audited). Controllers stay
+transport-only; queries live in small dedicated controller methods (no new manager
+surface — these are lookups, not writes).
+
+## Bridge additions (doSSOClients.php)
+
+Three new cases in the existing action switch — `org_search`, `dept_list`,
+`user_search` — each a mechanical proxy to the endpoints above, same response
+bridging (`{success, retData}`) the page already consumes.
+
+## The experience (practical-polish tier)
+
+- **Client list**: `el-table` — name, slug, email domains as tags, enabled/disabled
+  status tag, certificate expiry with a red `EXPIRING` tag (30-day window). Row
+  actions: edit, enable/disable. Empty state with a "create your first client" hint.
+- **Create/edit form** (an `el-dialog`; the metadata and grants panels live in an
+  inline detail section that appears when a row is selected):
+  - Organization: `el-select` with remote search — type a name, see "Name (ID)",
+    never type a raw ID.
+  - Default department: dependent `el-select`, populated from the chosen org, with an
+    explicit "None — users choose at finish-account" option mapping to null (same
+    semantics as the CLI wizard).
+  - Slug: auto-derived from name on create (placeholder shows the derivation), locked
+    on edit.
+  - Email domains: editable tag list (type, enter, tag appears; click x to remove).
+  - Attribute map: three fields grouped under a hint that Entra/ADFS send full claim
+    URIs (the milestone-2 lesson, surfaced where the admin needs it).
+  - 422 error bags map to per-field form errors (`el-form-item` error prop),
+    including dotted keys (`attribute_map.email`).
+- **IdP metadata**: dialog with paste textarea; on success shows parsed entity ID,
+  SSO URL, and cert expiry; failures show the API's message inline.
+- **Enable/disable**: `el-popconfirm`; success toast (`$message`) naming the client.
+- **Grants panel** (detail view): user autocomplete via `user_search` showing
+  "First Last — login (Department)"; granted users render as removable tags with the
+  grantor in a tooltip; add/remove saves via the existing replace semantics.
+- **States**: loading indicators on every remote call; disabled submit while busy;
+  toasts for success; a single error banner only for unreachable-service failures.
+
+## Build and asset story
+
+`admincomponents` builds locally (`npm ci && npm run build` in
+`website_admin/admincomponents`) and its `dist/` is committed — the portal's existing
+convention. No pipeline changes.
+
+**Plan-time checkpoint (blocking):** verify the Vue-CLI-era toolchain still builds on
+node 24 before any component work. Small pins are acceptable; if it needs major
+surgery, stop and reassess the approach rather than yak-shaving the build.
+
+## Testing
+
+- **Login app**: feature tests for the three lookup endpoints (query filtering,
+  org scoping, active-department filtering, limit, auth via middleware group).
+- **Dusk**: rewrite the five SSO-page browser tests against the new Element UI DOM
+  (same behaviors: list, create-with-422-then-success, enable/disable, grants
+  add/remove, plus the smoke), and add one new test proving the relationship UX:
+  search the org picker, select a result, verify the form carries the org and the
+  department dropdown populates.
+- `make e2e` (SAML flows, session handoff) unaffected.
+
+## Branch strategy
+
+Login-app work on `milestone4-ux`, stacked on `milestone4-admin` (keeps the reviewed
+milestone core separable). Portal work continues as commits in the sibling
+`website_admin` repo (dist rebuilt and committed alongside src changes).
+
+## Out of scope
+
+- Visual redesign beyond Element UI defaults (no custom theme work).
+- Dashboard-tier extras (setup-progress indicators, copy buttons, avatars) — noted as
+  a possible later tier.
+- Touching any other admin page, or upgrading Vue/Element UI versions.
+- New write endpoints — the three additions are lookups only.

--- a/docs/specs/2026-07-09-admin-portal-sso.md
+++ b/docs/specs/2026-07-09-admin-portal-sso.md
@@ -1,0 +1,126 @@
+# Admin Portal SSO — Design
+
+Bonus effort beyond the fixed-bid milestones: put the legacy admin portal
+(`website_admin`) itself behind SAML SSO, so Apex employees sign into it through the
+company IdP instead of (or alongside) the portal's static-salted-MD5 password check
+(`doLogon.php`). Feature-flagged so it can be switched on and off at runtime without a
+deploy.
+
+Two codebases again: the SAML/identity side in this repo, a small callback script and
+login button in `website_admin` (sibling checkout).
+
+## The flag
+
+A new boolean column `admin_portal` on `saml_clients` (default false; settable via
+`saml:client create/update --admin-portal`, surfaced in the admin API and portal page).
+One client row — slug `apex-admin`, pointed at the internal IdP — carries it.
+
+The client's existing `enabled` state **is** the feature flag. `saml:client disable
+apex-admin` (or the portal page's disable button) switches admin SSO off at runtime;
+the SP-login and ACS endpoints already 404 disabled clients server-side, and the
+portal's SSO button hides itself (below). No env vars, no deploy, one source of truth.
+
+An `admin_portal` client is excluded from `/sso/lookup` email-domain routing and the
+domain-claim machinery entirely — it never participates in customer SP-initiated flows.
+
+Password login (`doLogon.php`) stays fully functional regardless of the flag. SSO is
+additive; if the IdP or the login app is down, admins still get in. Retiring the MD5
+path is a separate, later decision.
+
+## Trust model
+
+Portal admins are `Employees` rows (keyed by corporate `Email`, `Active = 'Y'`).
+Membership in that table is the authorization — the ACS matches the asserted email
+against `Employees` and **fails closed**: no row, or an inactive row, means the
+standard rejection page with a logged `reason` (`no_employee_match`). There is no JIT
+provisioning and no fallback to the `Users` table on an `admin_portal` client, and no
+`Auth::login()` either — a Laravel session in the login app means nothing to the
+portal. Existing per-page `Level`/`SalesRep` checks keep working untouched, since they
+read the same Employees row.
+
+The handoff into the portal's own session realm reuses the milestone-4 service-token
+bridge rather than teaching the login app to forge `ApexAdmin` sessions:
+
+- **One-time token.** After a successful match the ACS stores
+  `{employee_id, name}` in the cache under `admin_sso:token:{64-char random}`,
+  TTL 60 seconds, and 302s the browser to `{portal_url}/ssoLogon.php?token=...`.
+- **Server-side redemption.** `POST /api/admin/sso-handoff/redeem` (behind
+  `admin.api`, same `ADMIN_API_TOKEN`) atomically deletes-and-returns the payload;
+  a second redemption of the same token fails. Possession of the redirect URL alone
+  is useless without the portal's server-side API credential.
+
+Rejected alternatives: the login app writing the `ApexAdmin` Redis session directly
+(couples it to the portal session handler's ID-encryption and serialization internals —
+mousetrap-y, kept as a fallback if the callback approach hits deploy friction);
+portal-side php-saml (duplicates the whole milestone-2 stack in legacy PHP with no test
+harness).
+
+## ACS branch (this repo)
+
+`SamlController::acs` gains one branch: when `$client->admin_portal`, skip the
+`SamlUserProvisioner` / session establishment entirely and call an
+`AdminSsoHandoff` service — look up the Employee, mint the token, redirect. Everything
+before the branch (signature validation, replay guard, cert-expiry warning, identity
+extraction via the client's `attribute_map`) is shared with the normal flow unchanged.
+The success log line records `employee_id` rather than `user_id`.
+
+New config: `saml.admin_portal_url` (env `ADMIN_PORTAL_URL`) — the base the ACS
+redirects to. Local: the website container's admin path; prod:
+`https://www.apexinnovations.com/admin`.
+
+## Portal side (`website_admin`)
+
+New `ssoLogon.php`, mirroring `doLogon.php`'s contract:
+
+1. `require SESSIONCONFIG.php` — native `ApexAdmin` session, nothing custom.
+2. Redeem `$_GET['token']` server-to-server via the same curl/env pattern as
+   `doSSOClients.php`'s `loginApi()` helper.
+3. On success: `session_regenerate_id(true)` (fixation), set `$_SESSION['AdminID']`
+   and `$_SESSION['AdminName']`, set `$_SESSION['SSOLogin'] = true`, insert the
+   `AdminEvents` type-1 (login) row via `apx_AdminEvent` — insert failure is access
+   denied, exactly like `doLogon.php` — then redirect to `Home.php`.
+4. Any failure: redirect to `Home.php?error=Access Denied`, same as password failures.
+
+`HEADER.php` changes:
+
+- A "Sign in with SSO" button beside the existing login form, linking to the login
+  app's `/saml/apex-admin/login`. Shown only when the flag is on: a small server-side
+  check through the API bridge (`GET /api/admin/saml-clients/apex-admin`, result cached
+  in the session for 60 seconds) — if the check errors or the client is missing or
+  disabled, the button hides and nothing else is affected.
+- The 90-day `PasswordLastChanged` forced-reset redirect is skipped when
+  `$_SESSION['SSOLogin']` is set — password age is meaningless in an SSO session.
+
+## Testing
+
+Login app (phpunit, MySQL):
+
+- `admin_portal` flag: migration, CLI `--admin-portal`, API create/update/detail.
+- ACS matcher: active Employee matches; inactive and unknown emails rejected with
+  `no_employee_match`; a non-admin client's flow is completely unaffected; no `Users`
+  row is created or touched.
+- Handoff: token minted with TTL and correct payload; redeem returns it exactly once
+  (second call 404s); expired token 404s; redeem requires the admin token.
+- `/sso/lookup` never routes to an `admin_portal` client.
+
+End-to-end (Dusk + mock IdP + website container):
+
+- Seed a second mock client `local-admin-idp` with `admin_portal = true` (the mock
+  IdP's static `user1` email seeded as an active Employee, alongside `dev.admin`).
+  The `kristophjunge/test-saml-idp` image is configured for a single SP ACS URL, so
+  this likely means a second container instance (`mock-idp-admin`) in
+  `docker-compose.yml` pointing at `/saml/local-admin-idp/acs` — cheap, and keeps the
+  customer-flow mock untouched.
+- Flag on: click the SSO button on the portal login form → mock IdP → land on
+  `Home.php` with the admin menu rendered; `AdminEvents` has the type-1 row.
+- Flag off (`saml:client disable local-admin-idp`): button absent, `/saml/local-admin-idp/login` 404s.
+
+## Rollout
+
+1. Deploy the login app (inert: no `admin_portal` client exists; migration adds the
+   column automatically via the `migrations_login` startup migrate).
+2. Deploy `website_admin` (inert: flag off, button hidden, `ssoLogon.php` unreachable
+   without a token).
+3. `saml:client create` the `apex-admin` client against the internal IdP metadata,
+   `--admin-portal`, verify with a test employee, `enable` when satisfied.
+4. Switch off any time: `saml:client disable apex-admin` or the portal toggle.

--- a/docs/specs/2026-07-10-attribute-routing.md
+++ b/docs/specs/2026-07-10-attribute-routing.md
@@ -103,7 +103,7 @@ relations; `SamlOrgRule` / `SamlDepartmentRule` models (each with an
 
 ## The router
 
-`App\Saml\AttributeRouter::route(SamlClient $client, array $attributes): ?array`
+`App\Saml\AttributeRouter::route(SamlClient $client, array $attributes, ?int $fallbackOrganizationId = null): ?array`
 
 Returns `['organization_id' => int, 'department_id' => ?int]`, or `null`
 when no organization can be determined (system-owned, no org rule matched).
@@ -152,7 +152,9 @@ session (admin-portal clients branch away earlier and are untouched):
     org). Name sync unchanged.
 - `establishSession` puts `Organization` = placed org, falling back to the
   ownership spec's behavior (org-owned → owner org; system-owned → the
-  user's department's org).
+  user's department's org). The session `Organization` reflects a placement
+  only when it was applied (a resolved department or a JIT creation); an
+  unmoved existing user keeps their department's org.
 
 **Precedence note (org-owned):** when department rules exist and one
 resolves, it beats the client's static default department; the default is
@@ -175,6 +177,7 @@ the no-rule/no-match fallback only.
 - `department_name` is deliberately NOT validated against any org's
   departments (it is a cross-org template; the portal offers suggestions,
   the resolver handles absence by design).
+- Re-parenting a client requires clearing its routing rules first.
 
 ## Admin surfaces
 
@@ -234,8 +237,9 @@ the no-rule/no-match fallback only.
   malformed JSON.
 - **E2E (Dusk + mock IdP):** a department rule on `local-idp` keyed on the
   mock IdP's static `eduPersonAffiliation` (`group1` for user1) targeting
-  the seeded "SSO Department" by name → fresh JIT login lands there, not in
-  the finish flow. Portal Dusk test drives both sections of the rules panel
+  the seeded "SSO Department" by name → fresh JIT login lands on the finish
+  screen (credential still unset) with `DepartmentID` already routed, not 0.
+  Portal Dusk test drives both sections of the rules panel
   (add an org rule + a department rule via the pickers, save, reload,
   assert persisted).
 - **Docs:** onboarding runbook section — the two rule kinds and why

--- a/docs/specs/2026-07-10-attribute-routing.md
+++ b/docs/specs/2026-07-10-attribute-routing.md
@@ -1,0 +1,253 @@
+# Attribute-Based User Routing — Design
+
+Milestone 5 of the SSO contract: route SAML users to the right place in the
+Apex hierarchy (System → Organization → Department) based on what the
+customer's IdP asserts — department, role, group, or any other attribute —
+instead of the single static default department each client carries today.
+
+Builds directly on the polymorphic client ownership refactor
+(`docs/specs/2026-07-10-client-ownership.md`). Routing is **two separate
+ordered rule lists**, because the two questions are different and repeat
+differently:
+
+- **Organization rules** answer "which organization does this user belong
+  to?" — only meaningful on system-owned clients (an org-owned client's
+  organization *is* its owner; stage 1 is skipped).
+- **Department rules** answer "which department within that organization?" —
+  and target a **department name**, not a `Departments.ID`. A hospital
+  system with a dozen identically-structured orgs writes its department
+  mappings once; the name resolves against whatever organization stage 1
+  picked. No nullable columns anywhere: department rules simply have no
+  organization column.
+
+Rules read like Cloudflare page rules: "if the assertion matches [attribute]
+[operator] [value], then …".
+
+Scope decisions (settled during design):
+
+- **Rules decide placement only.** Credential/professional role stays with
+  the finish-account flow; rules never gate login (authorization stays
+  membership-based).
+- **Operators** (a closed set, shared by both rule kinds): `wildcard`,
+  `strict_wildcard`, `equals`, `not_equals`, `starts_with`,
+  `not_starts_with`, `contains`, `not_contains`, `ends_with`,
+  `not_ends_with`. Wildcards are `*`-patterns (zero or more characters,
+  anchored over the whole value); `wildcard` is case-insensitive,
+  `strict_wildcard` case-sensitive (Cloudflare's exact distinction). Every
+  other operator compares case-insensitively (deliberate deviation from
+  Cloudflare's case-sensitive `equals`: hospital IdPs emit inconsistent
+  casing).
+- **Operators are a native PHP backed enum, not loose strings.**
+  `App\Saml\RoutingOperator: string` (cases `Wildcard = 'wildcard'`,
+  `StrictWildcard = 'strict_wildcard'`, `Equals = 'equals'`, … all ten) is
+  the single source of truth: models cast to it, validators use
+  `Rule::enum(RoutingOperator::class)`, the router `match`es on enum cases
+  (exhaustive — a new case fails loudly until handled), the API serializes
+  `->value`, and the portal dropdown is generated from the same list.
+  Nothing compares raw operator strings anywhere.
+- **First match wins within each list — with resolution fall-through for
+  department rules.** A department rule only wins if it matches AND its
+  named department exists (active) in the resolved organization; otherwise
+  evaluation falls through to the next rule. Shared rule sets stay robust
+  when only 8 of 12 orgs have a Cath Lab.
+- **The IdP is authoritative, evaluated on every login** — for department
+  moves. A department rule that resolves to a department different from the
+  user's current one moves them (including across orgs when stage 1 says
+  so). No resolvable match changes nothing: routing never demotes or
+  unplaces anyone. Apex admins' manual placements survive only until the
+  IdP asserts something a department rule matches; the runbook says so
+  explicitly.
+- **The catch-all is spelled in the grammar — no nulls.** The reserved
+  triple `attribute = *`, `operator = wildcard`, `value = *` matches every
+  login (attribute `*` is a sentinel, only valid in exactly this
+  combination). Legal only as the **last** rule of its list; rules after a
+  catch-all are unreachable and rejected. An org-rule catch-all is how a
+  system client says "everyone else belongs to org X"; a department-rule
+  catch-all is "everyone else lands in the department named Y (where it
+  exists)".
+
+## Schema
+
+Two app-owned tables, stock Laravel conventions, additive migration (runs via
+the `migrations_login` startup migrate):
+
+`saml_org_rules` — system-owned clients only:
+
+| column          | type            | notes                                              |
+|-----------------|-----------------|----------------------------------------------------|
+| id              | bigint pk       |                                                    |
+| saml_client_id  | unsigned bigint | rules die with the client                          |
+| position        | unsigned int    | evaluation order; unique per client                |
+| attribute       | string          | assertion attribute name, verbatim as the IdP emits it (full claim URI for Entra); `*` reserved for the catch-all |
+| operator        | string          | `RoutingOperator` value; model casts to the enum   |
+| value           | string          | match value / `*`-pattern                          |
+| organization_id | int             | legacy `Organizations.ID`; must be in the owner's scope |
+| timestamps      |                 |                                                    |
+
+`saml_department_rules` — both ownership kinds:
+
+| column          | type            | notes                                              |
+|-----------------|-----------------|----------------------------------------------------|
+| id              | bigint pk       |                                                    |
+| saml_client_id  | unsigned bigint | rules die with the client                          |
+| position        | unsigned int    | evaluation order; unique per client                |
+| attribute       | string          | as above; `*` reserved                             |
+| operator        | string          | `RoutingOperator` value                            |
+| value           | string          | match value / `*`-pattern                          |
+| department_name | string          | matched case-insensitively against the resolved org's active departments' `Name` |
+| timestamps      |                 |                                                    |
+
+`SamlClient` gains ordered `orgRules()` / `departmentRules()` hasMany
+relations; `SamlOrgRule` / `SamlDepartmentRule` models (each with an
+`isCatchAll(): bool` helper) + factories follow app-owned conventions.
+
+## The router
+
+`App\Saml\AttributeRouter::route(SamlClient $client, array $attributes): ?array`
+
+Returns `['organization_id' => int, 'department_id' => ?int]`, or `null`
+when no organization can be determined (system-owned, no org rule matched).
+
+- **Stage 1 — organization.** Org-owned: the owner org, always (org rules
+  are invalid on such clients and ignored defensively). System-owned: walk
+  `orgRules` in position order, first match wins; no match → `null` (the
+  caller decides what that means for new vs existing users).
+- **Stage 2 — department.** Fetch the resolved org's active department
+  names once (`Departments` where `OrganizationID`, `Active = 'Y'`). Walk
+  `departmentRules` in position order; the first rule that **matches the
+  assertion AND whose `department_name` resolves** (case-insensitive) wins →
+  that department's ID. None resolve → `department_id = null` (finish-account
+  flow in the resolved org).
+- SAML attributes are multi-valued. **Positive operators** match when any
+  asserted value satisfies the comparison; an absent attribute never
+  matches. **Negated operators** (`not_*`) match when **no** asserted value
+  satisfies the positive form — vacuously including an absent attribute.
+- Wildcards: `preg_quote`, then `\*` → `.*`, wrapped `/^…$/u` (+`i` for
+  `wildcard`). The catch-all triple always matches.
+- One `Departments` query per login on the resolved org; otherwise a pure
+  function over its inputs — no user lookups, no session, no logging.
+
+## Login flow integration
+
+`SamlController::acs` orchestrates: it already holds `$auth->getAttributes()`;
+it calls the router once and hands the result to the provisioner and the
+session (admin-portal clients branch away earlier and are untouched):
+
+- `SamlUserProvisioner::provision(SamlClient $client, string $email,
+  ?string $firstName, ?string $lastName, ?array $placement): User`
+  - **JIT creation:** placement with department → that `DepartmentID`;
+    placement without department → `DepartmentID = 0` (finish-account in the
+    placed org); `null` placement on an **org-owned** client → impossible
+    (stage 1 always yields the owner; JIT default `$client->department_id ??
+    0` applies when no department rule resolves — via a department-rule-less
+    list this degrades to exactly today's behavior); `null` placement on a
+    **system-owned** client → the ownership spec's `unrouted_user` rejection
+    (an org-rule catch-all is how to accept everyone).
+  - **Existing users:** a placement whose department differs from the user's
+    current `DepartmentID` moves them and logs (`SAML routed user to
+    department`, client slug, user id, from, to). Department-less and `null`
+    placements leave the user untouched. For system-owned existing users
+    with no org-rule match, stage 2 resolves against the user's current
+    department's org (their placement can still be corrected within their
+    org). Name sync unchanged.
+- `establishSession` puts `Organization` = placed org, falling back to the
+  ownership spec's behavior (org-owned → owner org; system-owned → the
+  user's department's org).
+
+**Precedence note (org-owned):** when department rules exist and one
+resolves, it beats the client's static default department; the default is
+the no-rule/no-match fallback only.
+
+## Validation
+
+`SamlClientManager::replaceRoutingRules(SamlClient $client, array $orgRules, array $departmentRules): SamlClient`
+
+- Replace-both-lists semantics in one transaction (grants precedent):
+  validates every rule before touching rows; positions assigned from array
+  order.
+- Org rules: only accepted for system-owned clients (org-owned with a
+  non-empty org-rule list → ValidationException); `organization_id` must be
+  in `scopedOrganizationIds()`.
+- Both lists: `attribute`, `operator`, `value` (and `department_name` /
+  `organization_id` respectively) required non-empty; `operator` via
+  `Rule::enum(RoutingOperator::class)`; attribute `*` only in the exact
+  catch-all triple; catch-all only in the final position of its list.
+- `department_name` is deliberately NOT validated against any org's
+  departments (it is a cross-org template; the portal offers suggestions,
+  the resolver handles absence by design).
+
+## Admin surfaces
+
+- **API** (admin.api group, audited):
+  - `GET /api/admin/saml-clients/{slug}/routing-rules` →
+    `{org_rules: […], department_rules: […]}`, each ordered, org rules with
+    `organization_name` alongside the ID, plus derived `catch_all` flags.
+  - `PUT /api/admin/saml-clients/{slug}/routing-rules` → replaces both lists
+    atomically; body `{org_rules: [{attribute, operator, value,
+    organization_id}], department_rules: [{attribute, operator, value,
+    department_name}]}`. Audit context logs both counts and the rule tuples.
+  - `GET /api/admin/saml-clients/{slug}/routable-organizations` → the owner
+    scope's organizations (portal picker for org-rule targets).
+- **CLI:** `saml:client routing {slug}` renders both lists as sentences
+  (`org 1. hospital equals "Mercy West" → Mercy West`, `dept 2. department
+  contains "ICU" → "ICU Nursing"`). Replacement takes JSON — the same object
+  the PUT endpoint accepts — via `--set '<json>'` or `--set-file=<path>`;
+  `--clear` empties both lists. `describe` shows rule counts. (No wizard
+  mode — the portal is the friendly editor.)
+- **Portal** (`website_admin`, SSO Clients island): a "Routing" panel in the
+  edit dialog with two sections. Organization rules (system-owned clients
+  only): attribute / operator dropdown / value → org dropdown
+  (routable-organizations). Department rules: attribute / operator dropdown /
+  value → department-name input with suggestions (union of department names
+  across the owner scope, via the existing departments lookup per org).
+  Operator dropdown labels: "equals", "does not equal", "wildcard
+  (case-insensitive)", "strict wildcard (case-sensitive)", …. A "match
+  everyone" toggle per row fills the reserved `*` / `wildcard` / `*` triple
+  and disables the match inputs (last row of its list only). Add / remove /
+  reorder per list, saved via the bridge to the PUT endpoint. Bundle rebuilt
+  via the node:14 container, dist committed.
+
+## Testing
+
+- **Unit (router):** stage-1 org resolution (org-owned always owner;
+  system-owned first-match; no-match null); every operator positive and
+  negative, wildcard vs strict_wildcard case behavior, anchored patterns;
+  negated operators against multi-valued attributes and absent attributes
+  (vacuous match); positive operators never match absent attributes;
+  stage-2 fall-through (matching rule whose name is missing in the resolved
+  org yields to a later resolvable rule); department-name case-insensitive
+  resolution against active departments only; catch-alls in both lists;
+  empty lists.
+- **Feature:** system-owned JIT routed cross-org via the seeded local
+  system; org-rule catch-all rescues an otherwise-unrouted system JIT;
+  unrouted system JIT without catch-all rejected (`unrouted_user`);
+  org-owned JIT with a resolving department rule beats the static default;
+  org-owned unrouted keeps today's default/finish behavior; existing user
+  moved on resolving department rule (same-org and cross-org); existing
+  user untouched when nothing resolves (never demoted); system-owned
+  existing user with no org match gets own-org department correction and
+  correct session org; disabled-user and JIT-off paths unaffected; manager
+  validation (org rules on an org-owned client, org outside owner scope,
+  unknown operator, `*` outside the exact triple, rules after a catch-all,
+  empty fields) rejects atomically; API GET/PUT round trip + audit +
+  routable-organizations; CLI list, `--set` inline, `--set-file`, `--clear`,
+  malformed JSON.
+- **E2E (Dusk + mock IdP):** a department rule on `local-idp` keyed on the
+  mock IdP's static `eduPersonAffiliation` (`group1` for user1) targeting
+  the seeded "SSO Department" by name → fresh JIT login lands there, not in
+  the finish flow. Portal Dusk test drives both sections of the rules panel
+  (add an org rule + a department rule via the pickers, save, reload,
+  assert persisted).
+- **Docs:** onboarding runbook section — the two rule kinds and why
+  (write-once department templates), ordering + fall-through semantics, the
+  ten operators (negation-vs-multi-valued, wildcard case rules), catch-alls,
+  owner-scope confinement, the IdP-authoritative caveat (manual placements
+  are overridden on the next login a department rule resolves), and
+  Entra/Okta attribute-name reminders.
+
+## Rollout
+
+Branch `milestone5-routing` stacked on `client-ownership` (login) and a
+stacked `website_admin` branch for the portal panel — same PR pattern as
+milestones 3/4/bonus. Deploy is inert: no rules exist until an admin creates
+them; org-owned behavior without rules is byte-for-byte today's.

--- a/docs/specs/2026-07-10-client-ownership.md
+++ b/docs/specs/2026-07-10-client-ownership.md
@@ -1,0 +1,118 @@
+# Polymorphic Client Ownership — Design
+
+Prerequisite refactor for milestone 5 (attribute routing). The Apex hierarchy
+is **System → Organization → Department**, and a hospital system commonly runs
+one IdP and one email domain across all of its organizations. Today a SAML
+client is anchored to exactly one organization (`saml_clients.organization_id`),
+which makes a system-wide client impossible without crowning an arbitrary
+"home org". This refactor lets a client be owned at **either level**:
+
+- `owner_type = 'organization'` — exactly today's semantics, unchanged
+  behavior everywhere.
+- `owner_type = 'system'` — the client spans the system's organizations;
+  placement of new users comes from routing rules (the milestone 5 spec,
+  stacked on this one). Until rules exist, a system-owned client serves
+  existing users only.
+
+Nothing in milestones 2–4 has merged or deployed, so this lands as ordinary
+migrations on top of the stack — the reviewed PRs stay untouched and the
+shared production database sees one coherent migration sequence at first
+deploy.
+
+## Schema
+
+One migration, two tables, both reversible:
+
+- `saml_clients`: add `owner_type` (string) + `owner_id` (unsigned int),
+  backfill `('organization', organization_id)` for every row, then drop
+  `organization_id`.
+- `sso_grants`: the same — add owner pair, backfill from `organization_id`,
+  drop it; unique key becomes `(user_id, owner_type, owner_id)`. Grants are
+  **owner-scoped**: an org-owned client's manager list is exactly today's
+  org list; a system-owned client has one system-level manager list.
+
+`SamlClient` gains the scope helpers everything else consumes:
+
+- `ownedByOrganization(): bool`
+- `ownerName(): ?string` — Organizations.Name or Systems.Name
+- `scopedOrganizationIds(): array` — org-owned → `[owner_id]`; system-owned →
+  the system's organization IDs via `SystemOrganizations` (an organization
+  belongs to exactly one system by business rule; the join table doesn't
+  enforce it, so the query simply selects by `SystemID = owner_id`).
+
+## Validation (SamlClientManager)
+
+- Create requires exactly one owner: `owner_type` ∈ {organization, system} +
+  `owner_id` that exists in the corresponding legacy table. Update may
+  re-parent with the same validation.
+- `department_id` (the JIT default) is only legal on org-owned clients and
+  must belong to the owning organization — this also closes the milestone-4
+  backlog gap (department existence/ownership was never validated). A
+  system-owned client's `department_id` must be null; re-parenting to system
+  ownership with a default department set is rejected until it's cleared.
+- Grants replacement validates each granted user's department belongs to an
+  organization in `scopedOrganizationIds()`.
+
+## Login flow
+
+- **Existing users:** unchanged for org-owned. For system-owned, the session
+  `Organization` key comes from the user's department's organization (the
+  client has no single org to offer).
+- **New JIT users on system-owned clients are rejected** (standard rejection
+  page, logged `reason: unrouted_user`): with no home org there is nowhere to
+  aim the finish-account flow. The routing spec relaxes exactly this — rules
+  (including an explicit catch-all) become the placement mechanism.
+- Org-owned JIT, name sync, disabled checks, domains, the admin-portal
+  (bonus) branch: all byte-for-byte unchanged.
+
+## Admin surfaces
+
+- **API:** `item()`/`detail()` replace `organization_id`/`organization_name`
+  with `owner: {type, id, name}`; `grants_count` counts the owner's list.
+  Create/update accept `owner_type` + `owner_id`. The grants endpoints keep
+  their shapes, scoped by owner. The user-search lookup (grants picker)
+  searches across `scopedOrganizationIds()`.
+- **CLI:** `saml:client create` takes `--org=<id>` XOR `--system=<id>`
+  (replacing the required `--org`); `update` accepts either to re-parent.
+  `list` shows an Owner column (`org #5` / `system #2`); `describe` shows
+  `Owner: organization 5 (Name)` style. The wizard asks owner type first,
+  then searches the matching table.
+- **Portal (SSO Clients island):** create/edit dialogs get an owner-type
+  radio (Organization / System) driving which picker shows; a system picker
+  backed by a new `GET /api/admin/systems` lookup (search-by-name, same shape
+  as the organizations lookup). Grants panel unchanged visually — its user
+  search just widens with the scope. Bundle rebuilt via the node:14
+  container, dist committed.
+
+## Local dev
+
+`ReferenceDataSeeder` seeds System 1 ("Local Health System") containing
+organizations 1 and 2 through `SystemOrganizations`, so a system-owned client
+is testable locally (org 933 / SSO Organization stays system-less — the
+degenerate case stays covered). Existing seeded clients become
+`owner_type = 'organization'` via the backfill, no seeder changes needed
+beyond the column rename in explicit attributes.
+
+## Testing
+
+- Migration/backfill: existing factory rows and seeded clients land as
+  org-owned with identical behavior (the whole existing suite is the
+  regression net — it must stay green with only mechanical
+  `organization_id` → owner updates in test fixtures).
+- Scope helpers: org-owned scope = own org; system-owned scope = system's
+  orgs; system-less org degenerates to own-org-only.
+- Manager: owner validation (unknown org/system, missing/both owners),
+  default-department rules (org-owned belongs-to-org, system-owned must be
+  null, re-parent guard), grants scope validation across a system.
+- Login: system-owned existing-user session org; system-owned new-JIT
+  rejection with `unrouted_user`; org-owned paths unchanged.
+- API/CLI/portal: owner payloads, XOR flags, systems lookup, Dusk on the
+  reworked dialogs (create org-owned + create system-owned).
+
+## Rollout
+
+Branch `client-ownership`, stacked on `milestone-bonus` (login) with a
+companion `website_admin` branch stacked on `admin-portal-sso` for the dialog
+changes — same PR pattern. Deploy is inert: every existing client backfills
+to org-owned and behaves identically; system ownership only matters once an
+admin creates such a client.

--- a/docs/specs/2026-07-11-hierarchy-factory-tooling.md
+++ b/docs/specs/2026-07-11-hierarchy-factory-tooling.md
@@ -1,0 +1,131 @@
+# Hierarchy Factory Tooling — Design
+
+Dev tooling for generating a full System → Organizations → Departments tree in
+one expression, usable from both feature tests and local dev seeding. The
+building blocks already exist (`SystemFactory`, `OrganizationFactory`,
+`DepartmentFactory`, and the `SystemOrganizations` join), but composing them is
+verbose — `tests/Support/SeedsSystemHierarchy` hand-inserts join rows — and
+there is no local-dev entry point at all.
+
+Two facts shaped the design:
+
+- **System↔Organization is stored many-to-many but is semantically one-to-many.**
+  `SystemOrganizations` (own `ID` PK, `SystemID`, `OrganizationID`, no unique
+  index on `OrganizationID`) can hold multiple systems per org, but the business
+  rule is that an organization belongs to at most one system. Nothing in the DB
+  enforces this, so the tooling must — and the org-side relation should read as
+  singular.
+- **`Organization::systems()` has no consumers.** It is defined but never
+  called, so replacing it with the singular truth is a free correction, not a
+  migration.
+
+## Scope decisions (settled during design)
+
+- `forSystem()` accepts a `System` model, a string, or nothing. A string is a
+  lookup-or-create by `Name`, so repeated calls with the same name share one
+  system.
+- `withDepartments()` accepts an int (N distinct names from the realistic pool)
+  or an array of exact names (for tests that assert on a specific department).
+- A system-side, whole-tree entry point exists too:
+  `System::factory()->withOrganizations(3, departmentsEach: 4)`.
+- Local dev seeding follows the existing `Local*` seeder pattern
+  (`LocalHierarchySeeder`), not an artisan command.
+- Error handling stays minimal: this is dev/test-only code, so bad inputs (e.g.
+  a department name colliding with the per-org unique index) surface as natural
+  DB errors.
+
+## Data model corrections
+
+- `App\Models\SystemOrganization` becomes a real pivot: `extends Pivot`,
+  `$table = 'SystemOrganizations'`, `$primaryKey = 'ID'`, `$incrementing =
+  true`, `$timestamps = false`, fillable `SystemID`/`OrganizationID`.
+- `Organization::systems()` (belongsToMany, unused) is replaced by
+  `Organization::system()`, a
+  `hasOneThrough(System::class, SystemOrganization::class)` keyed
+  `OrganizationID`/`SystemID`, so `$org->system` reads as the single owning
+  system.
+- `System::organizations()` stays `belongsToMany` (a system genuinely has many
+  orgs) and gains `->using(SystemOrganization::class)`.
+
+## OrganizationFactory sugar
+
+`forSystem(System|string|null $system = null): static`
+
+Resolution is deferred to `afterCreating` so lookups happen at create time, not
+state-definition time:
+
+- `System` model → attach to it directly.
+- string → `System::where('Name', $name)->first() ?? System::factory()
+  ->create(['Name' => $name])`.
+- no argument → a fresh `System::factory()->create()`.
+
+The attach is `SystemOrganization::updateOrCreate(['OrganizationID' =>
+$org->ID], ['SystemID' => $system->ID])` — keyed on the org, which *enforces*
+the one-system rule: re-attaching replaces the row rather than adding a second
+system.
+
+`withDepartments(int|array $departments = 3): static`
+
+- int → `has(Department::factory()->count($n), 'departments')` with a shuffled
+  per-org `Sequence` over `DepartmentFactory::NAMES`. This deliberately
+  bypasses faker's global `unique()`, so seeding many orgs cannot exhaust the
+  24-name pool (names are unique per org, which is all the legacy
+  `UNIQUE(Name, OrganizationID)` index requires).
+- array → the same, sequenced over the exact names given.
+
+## SystemFactory sugar
+
+`withOrganizations(int $count = 2, int|array $departmentsEach = 3): static`
+
+Composes the above:
+`has(Organization::factory()->count($count)->withDepartments($departmentsEach),
+'organizations')`. One call builds the whole tree:
+
+```php
+System::factory()->withOrganizations(3, departmentsEach: 4)
+    ->create(['Name' => 'Memorial Health System']);
+```
+
+The belongsToMany `has()` writes the join rows through the pivot; orgs created
+this way get exactly one system by construction.
+
+## LocalHierarchySeeder
+
+Follows the `Local*` seeder pattern: creates one named system
+("Memorial Health System") with a few orgs of 3–4 departments each, plus one
+standalone org (no system) with departments — the no-system shape exists in
+production data and must stay exercised locally. Guarded by a name check so
+re-running does not duplicate. Run inside the Sail container:
+
+```bash
+php artisan db:seed --class=LocalHierarchySeeder
+```
+
+## Testing
+
+New cases in `tests/Feature/HierarchyFactoryTest`:
+
+- `forSystem('Same Name')` on two orgs shares a single system (one `Systems`
+  row, two join rows).
+- `forSystem($model)` attaches to the given system; `forSystem()` with no
+  argument creates a fresh one.
+- Re-attaching an org to a different system replaces the join row (one row per
+  org, hasOne enforced).
+- `$org->system` (hasOneThrough) returns the attached system.
+- `withDepartments(4)` creates four departments with distinct names;
+  `withDepartments(['Emergency', 'ICU'])` creates exactly those.
+- `withOrganizations(3, departmentsEach: 2)` builds the full tree: three orgs
+  each attached to the system, two departments each; also with an array of
+  names applied per org.
+- A many-org seed (e.g. 10 orgs × 3 departments) does not exhaust the name
+  pool.
+
+`SeedsSystemHierarchy` shrinks to the new sugar internally; its call sites are
+untouched.
+
+## Rollout
+
+Test/dev-only surface: no migrations, no production code paths touched beyond
+the unused `Organization::systems()` → `system()` relation swap and the inert
+pivot registration on `System::organizations()`. Stacks on
+`milestone5-routing`.

--- a/docs/specs/2026-07-11-known-attributes.md
+++ b/docs/specs/2026-07-11-known-attributes.md
@@ -1,0 +1,138 @@
+# Known Attributes & Capture History — Design
+
+Follow-on to milestone 5 (attribute routing). Today an admin building a routing
+rule must hand-type the exact SAML attribute name — full claim URIs for Entra,
+easy to typo, with nothing tying the field to what the customer's IdP actually
+sends. This feature captures the attribute *names* an IdP asserts on each login
+and offers them as a strict dropdown in the rule editor, backed by a names-only
+capture-history log for provenance.
+
+Two facts shaped the design:
+
+- **IdP metadata does not carry the attributes.** Okta and Entra configure
+  claims per-application; those names are not published in the
+  `<IDPSSODescriptor>` we already parse. The only reliable source is a real
+  assertion's `<AttributeStatement>`, which the ACS already has in hand via
+  `$auth->getAttributes()`.
+- **Assertion *values* are PHI/PII; attribute *names* are not.** This feature
+  persists names only. Value-level assertion logging (forensics grade) is a
+  separate, later, compliance-scoped spec and is explicitly out of scope here.
+
+## Scope decisions (settled during design)
+
+- Source: auto-capture from every login, plus manual add/remove.
+- Policy: merge-and-grow, never auto-shrink; capture on all non-admin-portal
+  clients.
+- Identity attributes (the three `attribute_map` values — email/first/last) are
+  excluded from capture: they are already handled by the fixed identity map and
+  would be noise in a routing dropdown. `attribute_map` is the exclusion filter,
+  not the storage.
+- The rule editor's attribute field is a **strict dropdown** over the client's
+  known set; the manual-add path is what unblocks building rules before the
+  first login (or for a claim the IdP will send but hasn't yet).
+
+## Schema
+
+Two additions, both additive/reversible (auto-run via `migrations_login`):
+
+`saml_clients.known_attributes` — json, default `[]`. The fast-read set the
+rule-editor dropdown consumes; a derived cache over the observation log below.
+Mirrors the existing `email_domains` json column exactly (fillable, `array`
+cast).
+
+`saml_attribute_observations` — the names-only capture history (provenance /
+backup for `known_attributes`):
+
+| column          | type            | notes                                         |
+|-----------------|-----------------|-----------------------------------------------|
+| id              | bigint pk       |                                               |
+| saml_client_id  | unsigned bigint | observations die with the client              |
+| name            | string          | the asserted attribute name (NEVER a value)   |
+| first_seen_at   | timestamp       | set once, on first observation                |
+| last_seen_at    | timestamp       | bumped every login the name appears           |
+| observation_count | unsigned int  | incremented every login the name appears      |
+| timestamps      |                 |                                               |
+
+Unique index `(saml_client_id, name)`. App-owned, stock conventions.
+`SamlClient` gains `attributeObservations(): HasMany`.
+
+## Capture (login hot path)
+
+`App\Saml\KnownAttributeCollector::capture(SamlClient $client, array $attributes): void`
+
+Called from `SamlController::acs` after identity extraction, **before** the
+admin-portal branch and the provisioner (admin-portal clients are skipped
+entirely — they assert Employee identities, not routing attributes).
+
+- Compute the candidate names: `array_keys($attributes)` minus the client's
+  `attribute_map` values (the identity attributes). Never touches values.
+- **Observation upsert (always):** for each candidate name, one
+  `updateOrInsert` on `(saml_client_id, name)` — set `first_seen_at` on insert,
+  bump `last_seen_at` + `observation_count` on update. This is the running
+  audit; it records every appearance regardless of whether the name is new.
+- **known_attributes merge (only when new):** if any candidate name is absent
+  from `$client->known_attributes`, union them in and persist the column once.
+  In steady state (no new names) this branch does zero writes to `saml_clients`.
+- The whole method is wrapped so any failure is logged
+  (`Log::warning('known-attribute capture failed', ...)`) and swallowed — a
+  capture problem must never break a login. It runs after the assertion is
+  already validated, so it never gates authentication.
+
+Cost per login: N small indexed upserts (N = distinct non-identity attributes,
+typically 1–5) plus at most one `saml_clients` update when the IdP adds a claim.
+Acceptable on the hot path; the upserts are the price of the audit trail the
+feature is meant to provide.
+
+## Manual management (manager + API)
+
+- `SamlClientManager` validates `known_attributes` (`sometimes`, array, each
+  entry a non-empty string; trimmed + de-duplicated) and adds it to
+  `EDITABLE_FIELDS`, so an admin adds/removes names through the existing update
+  path (and audit trail).
+- Removing a name a live rule still references is allowed — the rule matches
+  against the incoming assertion, not the known list, so it keeps working; the
+  portal warns rather than blocks. The name's observation row is left intact
+  (provenance survives a prune, and the next login re-adds it to
+  `known_attributes` if the IdP still sends it).
+- The client detail payload (`SamlClientController::detail`) returns
+  `known_attributes` and, for each, its `last_seen_at` from the observation log
+  (so the portal can distinguish live claims from stale ones). List payloads are
+  unchanged.
+
+## Rule editor (portal)
+
+- In both org-rule and department-rule rows, the attribute `el-input` becomes a
+  strict `el-select` populated from `detail.known_attributes`. Catch-all rows
+  still bypass the attribute field entirely (unchanged).
+- Empty-set affordance: when `known_attributes` is empty the select shows a
+  disabled hint ("No attributes captured yet — add one below, or complete a
+  test login"), so the editor is never a dead end.
+- A "Known attributes" strip in the routing section: a tag input (same idiom as
+  Email domains) to add a name, and removable tags to prune, each showing its
+  `last_seen_at` as a muted note ("seen 2d ago" / "never"). Saving posts through
+  the client update endpoint. Bundle rebuilt via the node:14 container, dist
+  committed.
+
+## Testing
+
+- **Unit/feature (collector):** unions asserted names into `known_attributes`;
+  excludes `attribute_map` values; writes `saml_clients` only when a name is
+  new (assert no update when nothing new); upserts an observation row per
+  candidate every login (first_seen set once, last_seen + count bump on repeat);
+  never persists a value anywhere; no-ops for admin-portal clients; a thrown
+  error inside capture does not break the ACS login (the login still succeeds).
+- **Feature (manager/API):** `known_attributes` validation (non-string,
+  duplicates, trimming); add/remove round trip; detail payload includes the set
+  with `last_seen_at`.
+- **E2E (Dusk + mock IdP):** a real `local-idp` login populates the set from the
+  mock assertion (`uid`, `eduPersonAffiliation`); the rule editor's attribute
+  dropdown then offers a captured name; a manual add on a fresh client unblocks
+  the dropdown before any login.
+
+## Rollout
+
+Additive and inert: existing clients start with `known_attributes = []` and an
+empty observation log, self-populating on the next login; the strict dropdown
+degrades gracefully to "add manually" until then. Stacks on `milestone5-routing`
+(login) and its portal twin, same PR. No behavior change to any existing login
+path beyond the swallowed, post-validation capture call.

--- a/docs/specs/2026-07-11-known-attributes.md
+++ b/docs/specs/2026-07-11-known-attributes.md
@@ -115,6 +115,26 @@ feature is meant to provide.
 
 ## Testing
 
+**Fixtures — use the fluent hierarchy factories, not the old helper.** Since
+this spec was written the factories gained a hierarchy builder; tests here build
+System → Organization → Department trees with it rather than hand-assembling
+`SystemOrganizations` rows or the `SeedsSystemHierarchy` trait:
+
+- `System::factory()->withOrganizations($orgCount, $deptsEach)` — whole tree in
+  one call (orgs attached via `SystemOrganizations`, each with departments).
+- `Organization::factory()->forSystem($system|$name|null)->withDepartments(int|array)`
+  — one org into a system (string looks up/creates a shared system; the join
+  row is keyed on the org, enforcing one-system-per-org), with a department
+  count or exact names.
+- `DepartmentFactory::NAMES` is the healthcare name pool; `withDepartments(int)`
+  sequences distinct names so per-org uniqueness holds without exhausting a
+  global `unique()`.
+
+Prefer these in new tests. The two existing routing tests that still use the
+`SeedsSystemHierarchy` trait (`AttributeRouterTest`, `RoutingRuleManagerTest`)
+may be migrated onto `withOrganizations()` opportunistically when this work
+touches them, but that migration is not required by this spec.
+
 - **Unit/feature (collector):** unions asserted names into `known_attributes`;
   excludes `attribute_map` values; writes `saml_clients` only when a name is
   new (assert no update when nothing new); upserts an observation row per
@@ -128,6 +148,9 @@ feature is meant to provide.
   mock assertion (`uid`, `eduPersonAffiliation`); the rule editor's attribute
   dropdown then offers a captured name; a manual add on a fresh client unblocks
   the dropdown before any login.
+
+  Cross-org capture/routing fixtures that need a system with several orgs use
+  `System::factory()->withOrganizations(...)` per the fixture note above.
 
 ## Rollout
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -174,6 +174,23 @@ certificate, re-run:
 php artisan saml:client update <slug> --metadata=<their-new-metadata.xml>
 ```
 
+## Admin portal
+
+SSO clients can also be managed from the legacy admin portal at
+`/admin/SSOClients.php` instead of the CLI: list clients, create a new one
+(with inline validation errors from the API), apply IdP metadata, enable or
+disable a client, and manage its organization grants (the "SSO managers"
+list of users permitted to administer that org's SSO settings). The portal
+page is a thin UI over this app's admin API — it does not talk to the
+database directly.
+
+The API it consumes lives in this app at `/api/admin/saml-clients` (see
+below). Both this application and the admin portal's application need
+`ADMIN_API_TOKEN` set (the same value in both `.env` files) for the portal
+to authenticate its API calls. The CLI (`saml:client ...`) remains fully
+equivalent to the portal for every operation the portal supports — use
+whichever is more convenient.
+
 ## Troubleshooting
 
 The application logs a `reason` value on every rejected SAML login. Use this

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -180,7 +180,9 @@ SSO clients can also be managed from the legacy admin portal at
 `/admin/SSOClients.php` instead of the CLI: list clients, create a new one
 (with inline validation errors from the API), apply IdP metadata, enable or
 disable a client, and manage its organization grants (the "SSO managers"
-list of users permitted to administer that org's SSO settings). The portal
+list of users permitted to administer that org's SSO settings). Organizations,
+departments, and grantable users are chosen through searchable pickers — no
+numeric IDs to look up, same as the CLI's `--wizard` mode. The portal
 page is a thin UI over this app's admin API — it does not talk to the
 database directly. Grants belong to the organization, not the individual
 client, so SSO clients that share an organization also share one grant list.

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -309,6 +309,38 @@ custom claim's full URI) — for an Entra client, the rule's `attribute` field
 needs the full claim URI, not the short name, the same reminder as the
 attribute map in Step 4 above.
 
+### Known attributes
+
+Writing a rule's `attribute` field from memory or a customer's IdP-config
+screenshot is error-prone, so the app tracks, per client, every attribute
+**name** it has actually seen asserted in a real login (excluding the
+identity attributes already covered by the attribute map). These are the
+client's **known attributes**, and they back two things in the portal's edit
+dialog: a "Known attributes" strip showing each captured name (with when it
+was last seen), and the routing-rule `attribute` field itself, which is a
+strict dropdown populated from this list rather than free text — a rule can
+only reference a name the client is known to have asserted (or one added
+manually, below).
+
+Only the attribute **name** is ever captured — never the value. Values are
+PHI for some customers, so the collector reads assertion keys and discards
+everything else; this is enforced at the point of capture, not by a filter
+downstream. `saml:client routing`/the portal's routing panel are the only
+consumers of this data.
+
+Known attributes populate automatically the first time a client's users log
+in — nothing to configure. To build a rule set *before* the first login (or
+to reference an attribute the IdP asserts only intermittently, e.g. a group
+claim that's empty for some users), add the name manually via the strip's
+input; it behaves the same as a captured one for rule-building purposes.
+Removing a known attribute from the strip only removes it from the dropdown
+going forward — it does not touch any routing rule already saved against
+that name, and the name reappears automatically the next time it's asserted.
+
+Full assertion logging (recording more than names, for audit purposes) is a
+separate, not-yet-built capability — do not rely on known attributes for
+anything beyond populating the routing-rule dropdown.
+
 ## Admin portal SSO (apex-admin)
 
 The admin portal itself can sit behind SSO. A SAML client marked

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -182,7 +182,8 @@ SSO clients can also be managed from the legacy admin portal at
 disable a client, and manage its organization grants (the "SSO managers"
 list of users permitted to administer that org's SSO settings). The portal
 page is a thin UI over this app's admin API — it does not talk to the
-database directly.
+database directly. Grants belong to the organization, not the individual
+client, so SSO clients that share an organization also share one grant list.
 
 The API it consumes lives in this app at `/api/admin/saml-clients` (see
 below). Both this application and the admin portal's application need
@@ -190,6 +191,10 @@ below). Both this application and the admin portal's application need
 to authenticate its API calls. The CLI (`saml:client ...`) remains fully
 equivalent to the portal for every operation the portal supports — use
 whichever is more convenient.
+
+**Rollout note:** the `sso_grants` migration must be run before the portal's
+grants panel ships to production — deploys do not run migrations
+automatically, and the client detail view 500s without that table.
 
 ## Troubleshooting
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -80,6 +80,14 @@ that system. System-owned clients cannot hold a default department; new users
 on them are rejected (`unrouted_user` in the logs) until attribute routing
 rules (milestone 5) place them — configure rules before enabling such a
 client. The SSO-manager grant list of a system-owned client is system-wide.
+Re-parenting a client to a different owner (CLI-only, `saml:client update
+<slug> --org=` / `--system=`) strands the old owner's grant list — the rows
+aren't deleted, they just stop applying to this client, and the new owner
+starts with an empty list of its own. For the same reason, retire a client by
+disabling it (`saml:client disable <slug>`) rather than deleting its
+`saml_clients` row by hand — there is no cascade, so a manually deleted row
+strands its grants and routing rules as orphaned data instead of cleanly
+removing them.
 
 #### Interactive alternative: `--wizard`
 
@@ -211,6 +219,95 @@ history in its own `migrations_login` table — the shared `migrations` table
 belongs to other applications and is never read or written. No manual
 migration step is needed; a failed migration stops the new container before
 it serves, leaving the previous deployment running.
+
+## Attribute-based routing
+
+Beyond the client's single static default department, a client can carry
+**routing rules** that place (and, on repeat logins, move) users based on
+what the customer's IdP actually asserts — department, role, group, or any
+other attribute — instead of a fixed default. Rules read like Cloudflare page
+rules: "if the assertion matches `[attribute] [operator] [value]`, then
+place here." Manage them via `saml:client routing <slug>` (CLI —
+list/`--set`/`--set-file`/`--clear`) or the "Routing rules" panel on a
+client's edit dialog in the admin portal; both talk to the same
+`/api/admin/saml-clients/{slug}/routing-rules` API endpoint (GET/PUT).
+
+There are two rule kinds, because they answer two different questions:
+
+- **Organization rules** — "which organization does this user belong to?"
+  Only meaningful on system-owned clients (an org-owned client's organization
+  *is* its owner, so this stage is skipped for it). Each rule targets a
+  specific `organization_id` from the client's owner scope. The portal only
+  shows this section for system-owned clients.
+- **Department rules** — "which department within that organization?" These
+  target a **department name**, not a numeric ID. A hospital system with a
+  dozen identically-structured organizations writes its department mappings
+  *once* — a rule naming "ICU Nursing" resolves independently against
+  whichever organization stage 1 picked, rather than needing one rule per
+  org/department pair. If the named department doesn't exist in the resolved
+  org, that's expected and not an error: evaluation just falls through to the
+  next rule (or falls through to the client's static default, or the
+  finish-account flow, if nothing resolves).
+
+**Ordering and fall-through:** within each list, rules are evaluated in
+order and the **first match wins** — with one refinement for department
+rules: a department rule only "wins" if it both matches the assertion *and*
+its named department actually resolves (exists and active) in the
+organization stage 1 picked. A matching rule whose department doesn't exist
+here yields to the next rule rather than stopping evaluation, which is what
+makes shared rule sets safe to reuse across organizations that don't all
+have the same departments.
+
+**Operators** (a closed set, shared by both rule kinds): `equals`,
+`not_equals`, `starts_with`, `not_starts_with`, `contains`, `not_contains`,
+`ends_with`, `not_ends_with`, `wildcard`, `strict_wildcard`. Two things to
+know before writing a rule:
+
+- SAML attributes are multi-valued. The positive operators (`equals`,
+  `contains`, …) match when **any** asserted value satisfies the comparison;
+  an absent attribute never matches. The negated operators (`not_equals`,
+  `not_contains`, …) match when **no** asserted value satisfies the positive
+  form — which means they match vacuously when the attribute is absent
+  entirely. Keep that in mind for a `not_equals` rule meant to exclude a
+  specific group: it also matches everyone who was never asserted a group at
+  all.
+- `wildcard` and `strict_wildcard` are `*`-pattern matches (zero or more
+  characters, anchored over the whole value). `wildcard` is
+  case-insensitive, matching every other operator; `strict_wildcard` is the
+  one case-sensitive operator in the set — reach for it only when a
+  customer's IdP asserts values whose casing is meaningful.
+
+**Catch-alls:** the reserved triple `attribute = *`, `operator = wildcard`,
+`value = *` matches every login. It's the only legal use of `*` as an
+attribute name, and it is only legal as the **last** rule in its list —
+anything placed after a catch-all can never be reached and is rejected at
+save time. An org-rule catch-all is how a system-owned client says
+"everyone else belongs to org X"; a department-rule catch-all says
+"everyone else lands in the department named Y, where it exists." The
+portal's "match everyone" checkbox on the last row of a list fills in this
+triple for you.
+
+**Owner-scope confinement:** an org rule's `organization_id` must be one of
+the client's `scopedOrganizationIds()` — the owning org itself for an
+org-owned client, or a member organization for a system-owned one. Rules
+that reach outside that scope are rejected, same as grants.
+
+**The IdP is authoritative, every login.** Department rules aren't a
+one-time placement — they're re-evaluated on every login. If a rule resolves
+to a department different from the user's current one, the user moves
+(including across organizations, if stage 1 says so). No-match logins never
+demote or unplace anyone, but a resolvable match always wins: a department
+an Apex admin sets by hand survives only until the next login where a
+department rule resolves to something else. Don't hand-place a user into a
+department a routing rule will contest.
+
+**Entra/Okta attribute names:** write the `attribute` field exactly as the
+IdP sends it. Okta sends short attribute names (`department`, `role`, …), so
+those work directly. Entra emits URI-style claim names by default (e.g.
+`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/department`, or a
+custom claim's full URI) — for an Entra client, the rule's `attribute` field
+needs the full claim URI, not the short name, the same reminder as the
+attribute map in Step 4 above.
 
 ## Admin portal SSO (apex-admin)
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -238,6 +238,7 @@ table to translate a logged reason into a cause and fix.
 | `no_email_attribute`          | The assertion did not carry an email in the attribute named by the client's attribute map, and no usable NameID was present either. | Fix the customer's attribute mapping (Okta attribute statements or Entra claim names) so the app's mapped `email` field is actually sent; verify with `saml:client list`/`update` that the attribute map matches what the IdP sends. |
 | `disabled_user`               | The matched Apex user has `Disabled='Y'`.                                                       | Reactivate the account in the admin site if the user should regain access.                              |
 | `unknown_user_jit_disabled`   | No existing Apex user matches the login, and JIT provisioning is off for this client.            | Either enable JIT (`saml:client update <slug> --jit`) or pre-create the user account manually before the customer's users start logging in. |
+| `no_employee_match`           | SAML login on an admin-portal client asserted an email with no active Employees row.             | Verify the employee's Email and Active='Y' in the Employees table; admin SSO never auto-creates accounts. |
 
 ## Validation checklist (run once against the Okta integrator account)
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -202,6 +202,30 @@ belongs to other applications and is never read or written. No manual
 migration step is needed; a failed migration stops the new container before
 it serves, leaving the previous deployment running.
 
+## Admin portal SSO (apex-admin)
+
+The admin portal itself can sit behind SSO. A SAML client marked
+`--admin-portal` asserts *Employee* identities (the portal's own auth table):
+the ACS matches `Employees.Email` (active rows only, never JIT-provisions),
+mints a 60-second single-use token, and redirects to the portal's
+`ssoLogon.php`, which redeems it server-to-server (`POST
+/api/admin/sso-handoff/redeem`, same `ADMIN_API_TOKEN` bridge as the SSO
+Clients page) and establishes the normal portal session. Password login is
+unaffected; both paths coexist.
+
+**The feature flag is the client's `enabled` state.** `saml:client disable
+apex-admin` (or the portal toggle) turns admin SSO off at runtime: the
+login/ACS endpoints 404 and the portal's "Sign in with SSO" button hides
+itself within a minute. Admin-portal clients cannot claim email domains and
+never appear in `/sso/lookup` routing.
+
+Rollout: deploy login app, deploy website_admin, then
+`saml:client create --name="Apex Admin" --org=<org> --admin-portal`,
+apply the internal IdP's metadata, verify with a test employee, and
+`saml:client enable apex-admin`. Set `LOGIN_SSO_CLIENT=apex-admin` in the
+portal's env. Local dev uses the second mock IdP (`mock-idp-admin`,
+client `local-admin-idp`, login user1/user1pass).
+
 ## Troubleshooting
 
 The application logs a `reason` value on every rejected SAML login. Use this

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -192,9 +192,13 @@ to authenticate its API calls. The CLI (`saml:client ...`) remains fully
 equivalent to the portal for every operation the portal supports — use
 whichever is more convenient.
 
-**Rollout note:** the `sso_grants` migration must be run before the portal's
-grants panel ships to production — deploys do not run migrations
-automatically, and the client detail view 500s without that table.
+**Rollout note:** migrations run automatically when a login container starts
+(the image entrypoint runs `php artisan migrate --force --isolated`). This is
+safe against the shared database because the login app tracks its migration
+history in its own `migrations_login` table — the shared `migrations` table
+belongs to other applications and is never read or written. No manual
+migration step is needed; a failed migration stops the new container before
+it serves, leaving the previous deployment running.
 
 ## Troubleshooting
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -229,8 +229,9 @@ other attribute — instead of a fixed default. Rules read like Cloudflare page
 rules: "if the assertion matches `[attribute] [operator] [value]`, then
 place here." Manage them via `saml:client routing <slug>` (CLI —
 list/`--set`/`--set-file`/`--clear`) or the "Routing rules" panel on a
-client's edit dialog in the admin portal; both talk to the same
-`/api/admin/saml-clients/{slug}/routing-rules` API endpoint (GET/PUT).
+client's edit dialog in the admin portal; both are backed by the same
+validated write path (`SamlClientManager`); the portal reaches it through the
+admin API.
 
 There are two rule kinds, because they answer two different questions:
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -71,6 +71,16 @@ IT admin can either configure their IdP directly from these three values, or
 fetch `GET <Metadata URL>` from their own tooling if it can consume SP
 metadata XML directly.
 
+### Organization vs system ownership
+
+A client is owned by a single organization (the default; users are placed via
+the client's default department or the finish-account flow) or by a hospital
+system (`saml:client create --system=<id>`), which spans every organization in
+that system. System-owned clients cannot hold a default department; new users
+on them are rejected (`unrouted_user` in the logs) until attribute routing
+rules (milestone 5) place them — configure rules before enabling such a
+client. The SSO-manager grant list of a system-owned client is system-wide.
+
 #### Interactive alternative: `--wizard`
 
 Instead of remembering the numeric organization and department IDs, run:
@@ -239,6 +249,7 @@ table to translate a logged reason into a cause and fix.
 | `disabled_user`               | The matched Apex user has `Disabled='Y'`.                                                       | Reactivate the account in the admin site if the user should regain access.                              |
 | `unknown_user_jit_disabled`   | No existing Apex user matches the login, and JIT provisioning is off for this client.            | Either enable JIT (`saml:client update <slug> --jit`) or pre-create the user account manually before the customer's users start logging in. |
 | `no_employee_match`           | SAML login on an admin-portal client asserted an email with no active Employees row.             | Verify the employee's Email and Active='Y' in the Employees table; admin SSO never auto-creates accounts. |
+| `unrouted_user`               | New user on a system-owned client with no matching routing rule.                                 | Add routing rules (including a catch-all) or verify the IdP asserts the expected attributes. |
 
 ## Validation checklist (run once against the Okta integrator account)
 

--- a/docs/sso-client-onboarding.md
+++ b/docs/sso-client-onboarding.md
@@ -192,7 +192,7 @@ certificate, re-run:
 php artisan saml:client update <slug> --metadata=<their-new-metadata.xml>
 ```
 
-## Admin portal
+## Managing clients from the admin portal (SSOClients.php)
 
 SSO clients can also be managed from the legacy admin portal at
 `/admin/SSOClients.php` instead of the CLI: list clients, create a new one
@@ -205,12 +205,11 @@ page is a thin UI over this app's admin API — it does not talk to the
 database directly. Grants belong to the organization, not the individual
 client, so SSO clients that share an organization also share one grant list.
 
-The API it consumes lives in this app at `/api/admin/saml-clients` (see
-below). Both this application and the admin portal's application need
-`ADMIN_API_TOKEN` set (the same value in both `.env` files) for the portal
-to authenticate its API calls. The CLI (`saml:client ...`) remains fully
-equivalent to the portal for every operation the portal supports — use
-whichever is more convenient.
+The API it consumes lives in this app at `/api/admin/saml-clients`. Both this
+application and the admin portal's application need `ADMIN_API_TOKEN` set
+(the same value in both `.env` files) for the portal to authenticate its API
+calls. The CLI (`saml:client ...`) remains fully equivalent to the portal for
+every operation the portal supports — use whichever is more convenient.
 
 **Rollout note:** migrations run automatically when a login container starts
 (the image entrypoint runs `php artisan migrate --force --isolated`). This is
@@ -344,9 +343,9 @@ table to translate a logged reason into a cause and fix.
 | `invalid_response`            | Signature, audience, timestamp, or destination validation failed — wrong certificate, clock skew between IdP and us, wrong ACS/entity ID configured at the IdP, or an unsigned assertion. | Re-check the IdP's SSO URL/Audience/ACS configuration against the values from `saml:client create`; re-apply current metadata with `saml:client update --metadata=`; confirm the IdP signs assertions. |
 | `replayed_assertion`          | The same assertion ID was submitted to the ACS more than once. Usually a double form submission (e.g. browser back/refresh) or a replay attempt. | Have the user retry login from the IdP tile. If this recurs for the same user/IdP, investigate for an actual replay attempt. |
 | `no_email_attribute`          | The assertion did not carry an email in the attribute named by the client's attribute map, and no usable NameID was present either. | Fix the customer's attribute mapping (Okta attribute statements or Entra claim names) so the app's mapped `email` field is actually sent; verify with `saml:client list`/`update` that the attribute map matches what the IdP sends. |
+| `no_employee_match`           | SAML login on an admin-portal client asserted an email with no active Employees row.             | Verify the employee's Email and Active='Y' in the Employees table; admin SSO never auto-creates accounts. |
 | `disabled_user`               | The matched Apex user has `Disabled='Y'`.                                                       | Reactivate the account in the admin site if the user should regain access.                              |
 | `unknown_user_jit_disabled`   | No existing Apex user matches the login, and JIT provisioning is off for this client.            | Either enable JIT (`saml:client update <slug> --jit`) or pre-create the user account manually before the customer's users start logging in. |
-| `no_employee_match`           | SAML login on an admin-portal client asserted an email with no active Employees row.             | Verify the employee's Email and Active='Y' in the Employees table; admin SSO never auto-creates accounts. |
 | `unrouted_user`               | New user on a system-owned client with no matching routing rule.                                 | Add routing rules (including a catch-all) or verify the IdP asserts the expected attributes. |
 
 ## Validation checklist (run once against the Okta integrator account)

--- a/phpunit.dusk.xml
+++ b/phpunit.dusk.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+    <testsuites>
+        <testsuite name="Browser Test Suite">
+            <directory suffix="Test.php">./tests/Browser</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\Admin\LookupController;
 use App\Http\Controllers\Api\Admin\SamlClientController;
 use App\Http\Controllers\Api\Admin\SsoGrantController;
 use Illuminate\Http\Request;
@@ -21,6 +22,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function () {
+    Route::get('/organizations', [LookupController::class, 'organizations'])->name('organizations.index');
+    Route::get('/organizations/{organizationId}/departments', [LookupController::class, 'departments'])->name('organizations.departments');
+    Route::get('/saml-clients/{slug}/users', [LookupController::class, 'users'])->name('saml-clients.users');
     Route::get('/saml-clients', [SamlClientController::class, 'index'])->name('saml-clients.index');
     Route::get('/saml-clients/{slug}', [SamlClientController::class, 'show'])->name('saml-clients.show');
     Route::post('/saml-clients', [SamlClientController::class, 'store'])->name('saml-clients.store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\Admin\SamlClientController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +17,9 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function () {
+    Route::get('/saml-clients', [SamlClientController::class, 'index'])->name('saml-clients.index');
+    Route::get('/saml-clients/{slug}', [SamlClientController::class, 'show'])->name('saml-clients.show');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\Admin\LookupController;
 use App\Http\Controllers\Api\Admin\SamlClientController;
 use App\Http\Controllers\Api\Admin\SsoGrantController;
+use App\Http\Controllers\Api\Admin\SsoHandoffController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -34,4 +35,5 @@ Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function 
     Route::post('/saml-clients/{slug}/disable', [SamlClientController::class, 'disable'])->name('saml-clients.disable');
     Route::get('/saml-clients/{slug}/grants', [SsoGrantController::class, 'index'])->name('saml-clients.grants.index');
     Route::put('/saml-clients/{slug}/grants', [SsoGrantController::class, 'replace'])->name('saml-clients.grants.replace');
+    Route::post('/sso-handoff/redeem', [SsoHandoffController::class, 'redeem'])->name('sso-handoff.redeem');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,4 +22,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function () {
     Route::get('/saml-clients', [SamlClientController::class, 'index'])->name('saml-clients.index');
     Route::get('/saml-clients/{slug}', [SamlClientController::class, 'show'])->name('saml-clients.show');
+    Route::post('/saml-clients', [SamlClientController::class, 'store'])->name('saml-clients.store');
+    Route::patch('/saml-clients/{slug}', [SamlClientController::class, 'update'])->name('saml-clients.update');
+    Route::post('/saml-clients/{slug}/idp-metadata', [SamlClientController::class, 'idpMetadata'])->name('saml-clients.idp-metadata');
+    Route::post('/saml-clients/{slug}/enable', [SamlClientController::class, 'enable'])->name('saml-clients.enable');
+    Route::post('/saml-clients/{slug}/disable', [SamlClientController::class, 'disable'])->name('saml-clients.disable');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\Admin\SamlClientController;
+use App\Http\Controllers\Api\Admin\SsoGrantController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -27,4 +28,6 @@ Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function 
     Route::post('/saml-clients/{slug}/idp-metadata', [SamlClientController::class, 'idpMetadata'])->name('saml-clients.idp-metadata');
     Route::post('/saml-clients/{slug}/enable', [SamlClientController::class, 'enable'])->name('saml-clients.enable');
     Route::post('/saml-clients/{slug}/disable', [SamlClientController::class, 'disable'])->name('saml-clients.disable');
+    Route::get('/saml-clients/{slug}/grants', [SsoGrantController::class, 'index'])->name('saml-clients.grants.index');
+    Route::put('/saml-clients/{slug}/grants', [SsoGrantController::class, 'replace'])->name('saml-clients.grants.replace');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function () {
     Route::get('/organizations', [LookupController::class, 'organizations'])->name('organizations.index');
-    Route::get('/organizations/{organizationId}/departments', [LookupController::class, 'departments'])->name('organizations.departments');
+    Route::get('/organizations/{organizationId}/departments', [LookupController::class, 'departments'])->whereNumber('organizationId')->name('organizations.departments');
     Route::get('/saml-clients/{slug}/users', [LookupController::class, 'users'])->name('saml-clients.users');
     Route::get('/saml-clients', [SamlClientController::class, 'index'])->name('saml-clients.index');
     Route::get('/saml-clients/{slug}', [SamlClientController::class, 'show'])->name('saml-clients.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\Admin\LookupController;
+use App\Http\Controllers\Api\Admin\RoutingRuleController;
 use App\Http\Controllers\Api\Admin\SamlClientController;
 use App\Http\Controllers\Api\Admin\SsoGrantController;
 use App\Http\Controllers\Api\Admin\SsoHandoffController;
@@ -36,5 +37,8 @@ Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function 
     Route::post('/saml-clients/{slug}/disable', [SamlClientController::class, 'disable'])->name('saml-clients.disable');
     Route::get('/saml-clients/{slug}/grants', [SsoGrantController::class, 'index'])->name('saml-clients.grants.index');
     Route::put('/saml-clients/{slug}/grants', [SsoGrantController::class, 'replace'])->name('saml-clients.grants.replace');
+    Route::get('/saml-clients/{slug}/routing-rules', [RoutingRuleController::class, 'show'])->name('saml-clients.routing-rules.show');
+    Route::put('/saml-clients/{slug}/routing-rules', [RoutingRuleController::class, 'replace'])->name('saml-clients.routing-rules.replace');
+    Route::get('/saml-clients/{slug}/routable-organizations', [RoutingRuleController::class, 'routableOrganizations'])->name('saml-clients.routable-organizations');
     Route::post('/sso-handoff/redeem', [SsoHandoffController::class, 'redeem'])->name('sso-handoff.redeem');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::prefix('admin')->middleware('admin.api')->name('admin.')->group(function () {
     Route::get('/organizations', [LookupController::class, 'organizations'])->name('organizations.index');
     Route::get('/organizations/{organizationId}/departments', [LookupController::class, 'departments'])->whereNumber('organizationId')->name('organizations.departments');
+    Route::get('/systems', [LookupController::class, 'systems'])->name('systems.index');
     Route::get('/saml-clients/{slug}/users', [LookupController::class, 'users'])->name('saml-clients.users');
     Route::get('/saml-clients', [SamlClientController::class, 'index'])->name('saml-clients.index');
     Route::get('/saml-clients/{slug}', [SamlClientController::class, 'show'])->name('saml-clients.show');

--- a/tests/Browser/AdminPortalLoginTest.php
+++ b/tests/Browser/AdminPortalLoginTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\Browser\Support\InteractsWithAdminPortal;
+use Tests\DuskTestCase;
+
+class AdminPortalLoginTest extends DuskTestCase
+{
+    use InteractsWithAdminPortal;
+
+    public function test_seeded_admin_can_log_into_the_portal(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $this->loginAsPortalAdmin($browser)
+                ->assertDontSee('not authorized to view this page')
+                ->assertSee('Dev Admin');
+        });
+    }
+}

--- a/tests/Browser/AdminPortalSsoTest.php
+++ b/tests/Browser/AdminPortalSsoTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\SamlClient;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+/**
+ * Full admin-portal SSO round trip against mock-idp-admin. Requires
+ * `make db` state with the mock-idp-admin container up (local-admin-idp
+ * enabled) — same convention as the other Browser suites.
+ */
+class AdminPortalSsoTest extends DuskTestCase
+{
+    private function adminUrl(): string
+    {
+        return env('DUSK_ADMIN_URL', 'http://localhost/admin');
+    }
+
+    private function setClientEnabled(bool $enabled): void
+    {
+        SamlClient::where('slug', 'local-admin-idp')->update(['enabled' => $enabled]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setClientEnabled(true); // leave make-db state behind for reruns
+
+        parent::tearDown();
+    }
+
+    public function test_sso_button_logs_admin_in_through_mock_idp(): void
+    {
+        $this->setClientEnabled(true);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->adminUrl().'/doLogoff.php') // fresh session
+                ->visit($this->adminUrl().'/Home.php')
+                ->waitForText('Sign in with SSO', 10)
+                ->clickLink('Sign in with SSO')
+                // kristophjunge simplesamlphp login form
+                ->waitFor('#username', 10)
+                ->type('#username', 'user1')
+                ->type('#password', 'user1pass')
+                ->press('Login')
+                // Home.php renders #adminID only with $_SESSION['AdminID'] set
+                ->waitFor('#adminID', 15)
+                ->assertSee('Mock IdPAdmin');
+        });
+    }
+
+    public function test_disabled_flag_hides_button_and_404s_login(): void
+    {
+        $this->setClientEnabled(false);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->adminUrl().'/doLogoff.php') // fresh session: SSOAvailable cache lives in it
+                ->visit($this->adminUrl().'/Home.php')
+                ->waitFor('#Logon', 10)
+                ->assertDontSee('Sign in with SSO');
+
+            $browser->visit(rtrim(env('APP_URL', 'http://localhost:8090'), '/').'/saml/local-admin-idp/login')
+                ->assertSee('404');
+        });
+    }
+}

--- a/tests/Browser/KnownAttributesTest.php
+++ b/tests/Browser/KnownAttributesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\SamlAttributeObservation;
+use App\Models\SamlClient;
+use App\Models\User;
+use Facebook\WebDriver\WebDriverBy;
+use Laravel\Dusk\Browser;
+use Tests\Browser\Support\InteractsWithAdminPortal;
+use Tests\DuskTestCase;
+
+/**
+ * End-to-end proof of the known-attribute capture path: drive a REAL
+ * local-idp SAML login (kristophjunge mock IdP asserts `uid`, `email`, and
+ * `eduPersonAffiliation` for user1 — see LocalSamlClientSeeder), then confirm
+ * the captured attribute name surfaces both in the database
+ * (saml_attribute_observations) and in the portal's routing-rule attribute
+ * dropdown / known-attributes strip. Requires `make db` state (fresh seed,
+ * local-idp enabled, its known_attributes/observations empty).
+ */
+class KnownAttributesTest extends DuskTestCase
+{
+    use InteractsWithAdminPortal;
+
+    private function idpUrl(): string
+    {
+        return rtrim(env('APP_URL', 'http://localhost:8090'), '/');
+    }
+
+    protected function tearDown(): void
+    {
+        // Unconditional cleanup so reruns are idempotent, even on failure:
+        // delete the JIT'd Users row (NOT the Employees row user1@example.com
+        // also occupies) and reset local-idp's captured attributes back to
+        // make-db state.
+        User::where('Login', 'user1@example.com')->delete();
+
+        $client = SamlClient::where('slug', 'local-idp')->first();
+        if ($client) {
+            $client->known_attributes = [];
+            $client->save();
+
+            SamlAttributeObservation::where('saml_client_id', $client->id)->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_real_saml_login_captures_attribute_name_and_surfaces_it_in_portal(): void
+    {
+        // --- Step 1: drive the REAL SAML flow through the mock IdP ---
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->idpUrl().'/saml/local-idp/login')
+                // kristophjunge simplesamlphp login form
+                ->waitFor('#username', 10)
+                ->type('#username', 'user1')
+                ->type('#password', 'user1pass')
+                ->press('Login')
+                ->waitForLocation('/finishAccountCreation', 15);
+        });
+
+        $this->assertDatabaseHas('saml_attribute_observations', [
+            'name' => 'eduPersonAffiliation',
+        ]);
+
+        // --- Step 2: confirm the captured name surfaces in the portal ---
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitSsoClientsPage($browser);
+
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'local-idp')]"));
+            $row->click();
+
+            $page->waitFor('.el-dialog', 10)
+                ->waitForText('Department rules', 10);
+
+            // The known-attributes strip renders one el-tag per captured
+            // name (SSOClientsApp.vue's `form.known_attributes` loop).
+            $page->waitForText('eduPersonAffiliation', 10);
+
+            // The routing attribute select is fed by the same
+            // known_attributes list — open the department-rule row's
+            // (freshly added, so the only one present) attribute select and
+            // confirm the captured name is offered as an option.
+            $page->press('Add department rule');
+
+            $page->script("var selects = document.querySelectorAll('.el-dialog input.el-input__inner[placeholder=\"attribute\"]'); selects[selects.length - 1].click();");
+            $this->waitForVisibleDropdownOption($page, 'eduPersonAffiliation');
+        });
+    }
+}

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Browser;
+
+class HomePage extends Page
+{
+    /**
+     * Get the URL for the page.
+     */
+    public function url(): string
+    {
+        return '/';
+    }
+
+    /**
+     * Assert that the browser is on the page.
+     */
+    public function assert(Browser $browser): void
+    {
+        //
+    }
+
+    /**
+     * Get the element shortcuts for the page.
+     *
+     * @return array<string, string>
+     */
+    public function elements(): array
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/Pages/Page.php
+++ b/tests/Browser/Pages/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Page as BasePage;
+
+abstract class Page extends BasePage
+{
+    /**
+     * Get the global element shortcuts for the site.
+     *
+     * @return array<string, string>
+     */
+    public static function siteElements(): array
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/RoutingRulesPanelTest.php
+++ b/tests/Browser/RoutingRulesPanelTest.php
@@ -24,32 +24,9 @@ class RoutingRulesPanelTest extends DuskTestCase
 
     private const SSO_DEPARTMENT_ID = 3; // seeded by ReferenceDataSeeder, org 933
 
-    private function adminUrl(): string
-    {
-        return env('DUSK_ADMIN_URL', 'http://localhost/admin');
-    }
-
     private function idpUrl(): string
     {
         return rtrim(env('APP_URL', 'http://localhost:8090'), '/');
-    }
-
-    /**
-     * Mirrors SsoClientsPageTest's page-load helper: the legacy portal
-     * intermittently serves a truncated response under Selenium — reload
-     * once rather than let one infra blip fail an otherwise-passing test.
-     */
-    private function visitPage(Browser $browser): Browser
-    {
-        $this->loginAsPortalAdmin($browser);
-
-        $url = $this->adminUrl().'/SSOClients.php';
-
-        try {
-            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
-        } catch (\Throwable $e) {
-            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
-        }
     }
 
     protected function tearDown(): void
@@ -71,7 +48,7 @@ class RoutingRulesPanelTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             // --- Step 1: add the department rule through the portal panel ---
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'local-idp')]"));
             $row->click();

--- a/tests/Browser/RoutingRulesPanelTest.php
+++ b/tests/Browser/RoutingRulesPanelTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\SamlClient;
+use App\Models\User;
+use App\Saml\SamlClientManager;
+use Facebook\WebDriver\WebDriverBy;
+use Laravel\Dusk\Browser;
+use Tests\Browser\Support\InteractsWithAdminPortal;
+use Tests\DuskTestCase;
+
+/**
+ * Round trip: configure a department routing rule through the portal's
+ * routing-rules panel on local-idp (org-owned, org 933 — see
+ * LocalSamlClientSeeder/ReferenceDataSeeder), then drive the REAL mock-IdP
+ * SAML flow and confirm the JIT'd user actually lands in the routed
+ * department rather than DepartmentID 0. Requires `make db` state (fresh
+ * seed, both mock IdPs enabled, local-idp's rules empty).
+ */
+class RoutingRulesPanelTest extends DuskTestCase
+{
+    use InteractsWithAdminPortal;
+
+    private const SSO_DEPARTMENT_ID = 3; // seeded by ReferenceDataSeeder, org 933
+
+    private function adminUrl(): string
+    {
+        return env('DUSK_ADMIN_URL', 'http://localhost/admin');
+    }
+
+    private function idpUrl(): string
+    {
+        return rtrim(env('APP_URL', 'http://localhost:8090'), '/');
+    }
+
+    /**
+     * Mirrors SsoClientsPageTest's page-load helper: the legacy portal
+     * intermittently serves a truncated response under Selenium — reload
+     * once rather than let one infra blip fail an otherwise-passing test.
+     */
+    private function visitPage(Browser $browser): Browser
+    {
+        $this->loginAsPortalAdmin($browser);
+
+        $url = $this->adminUrl().'/SSOClients.php';
+
+        try {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        } catch (\Throwable $e) {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Unconditional cleanup so reruns are idempotent, even on failure:
+        // delete the JIT'd Users row (NOT the Employees row user1@example.com
+        // also occupies) and clear local-idp's rules back to make-db state.
+        User::where('Login', 'user1@example.com')->delete();
+
+        $client = SamlClient::where('slug', 'local-idp')->first();
+        if ($client) {
+            app(SamlClientManager::class)->replaceRoutingRules($client, [], []);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_routing_rule_configured_in_portal_places_real_saml_login(): void
+    {
+        $this->browse(function (Browser $browser) {
+            // --- Step 1: add the department rule through the portal panel ---
+            $page = $this->visitPage($browser);
+
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'local-idp')]"));
+            $row->click();
+
+            $page->waitFor('.el-dialog', 10)
+                ->waitForText('Department rules', 10)
+                ->press('Add department rule');
+
+            // The routing section is below the grants panel; local-idp's
+            // rules are empty coming out of `make db`, so the freshly added
+            // department rule is the only row — identified by its
+            // "attribute" input placeholder rather than a brittle position
+            // (the section layout shifts with owner type / rule count).
+            $attributeInput = '.el-dialog input[placeholder="attribute"]';
+            $valueInput = '.el-dialog input[placeholder="value"]';
+            $deptNameInput = '.el-dialog input[placeholder="Department name"]';
+
+            $page->waitFor($attributeInput, 10)
+                ->type($attributeInput, 'eduPersonAffiliation');
+
+            // Operator select defaults to "equals" already (blankRule()) —
+            // it's what we want, so no need to open the dropdown.
+            $page->type($valueInput, 'group1')
+                ->type($deptNameInput, 'SSO Department');
+
+            $page->press('Save routing rules')
+                ->waitForTextIn('.el-message', 'saved', 20);
+        });
+
+        $this->assertDatabaseHas('saml_department_rules', [
+            'attribute' => 'eduPersonAffiliation',
+            'value' => 'group1',
+            'department_name' => 'SSO Department',
+        ]);
+
+        // --- Step 2: drive the REAL SAML flow through the mock IdP ---
+        $this->browse(function (Browser $browser) {
+            $browser->visit($this->idpUrl().'/saml/local-idp/login')
+                // kristophjunge simplesamlphp login form
+                ->waitFor('#username', 10)
+                ->type('#username', 'user1')
+                ->type('#password', 'user1pass')
+                ->press('Login')
+                ->waitForLocation('/finishAccountCreation', 15);
+        });
+
+        $this->assertDatabaseHas('Users', [
+            'Login' => 'user1@example.com',
+            'DepartmentID' => self::SSO_DEPARTMENT_ID,
+            'CredentialID' => 0,
+        ]);
+    }
+}

--- a/tests/Browser/RoutingRulesPanelTest.php
+++ b/tests/Browser/RoutingRulesPanelTest.php
@@ -54,20 +54,35 @@ class RoutingRulesPanelTest extends DuskTestCase
             $row->click();
 
             $page->waitFor('.el-dialog', 10)
-                ->waitForText('Department rules', 10)
-                ->press('Add department rule');
+                ->waitForText('Department rules', 10);
 
-            // The routing section is below the grants panel; local-idp's
-            // rules are empty coming out of `make db`, so the freshly added
-            // department rule is the only row — identified by its
-            // "attribute" input placeholder rather than a brittle position
+            // The routing attribute field is a strict el-select fed by
+            // known_attributes (Task 5) — local-idp has none coming out of
+            // `make db` (no login has happened yet), so the dropdown would
+            // be empty. Add the attribute manually via the known-attributes
+            // strip first (the documented escape hatch for building rules
+            // ahead of a first login) so the select below has an option.
+            $knownAttributeInput = '.el-dialog input[placeholder="attribute name — press Enter"]';
+            $page->waitFor($knownAttributeInput, 10)
+                ->type($knownAttributeInput, 'eduPersonAffiliation')
+                ->keys($knownAttributeInput, '{enter}');
+
+            $page->press('Add department rule');
+
+            // local-idp's rules are empty coming out of `make db`, so the
+            // freshly added department rule is the only row — identified by
+            // its "value" input placeholder rather than a brittle position
             // (the section layout shifts with owner type / rule count).
-            $attributeInput = '.el-dialog input[placeholder="attribute"]';
             $valueInput = '.el-dialog input[placeholder="value"]';
             $deptNameInput = '.el-dialog input[placeholder="Department name"]';
 
-            $page->waitFor($attributeInput, 10)
-                ->type($attributeInput, 'eduPersonAffiliation');
+            $page->waitFor($valueInput, 10);
+
+            // The department-rule row's attribute select is the last
+            // (freshly added) one on the page — open it and pick the
+            // known attribute we just added above.
+            $page->script("var selects = document.querySelectorAll('.el-dialog input.el-input__inner[placeholder=\"attribute\"]'); selects[selects.length - 1].click();");
+            $this->clickVisibleDropdownOption($page, 'eduPersonAffiliation');
 
             // Operator select defaults to "equals" already (blankRule()) —
             // it's what we want, so no need to open the dropdown.

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -132,11 +132,14 @@ class SsoClientsPageTest extends DuskTestCase
                 ->press('Save')
                 ->waitFor('.el-form-item__error', 10);
 
-            // Unique slug -> created.
+            // Unique slug -> created. Generous wait: this round-trips through
+            // the legacy portal's bridge (doSSOClients.php) which has been
+            // observed to slow down sharply under occasional load on this
+            // shared dev stack.
             $page->type('.el-dialog .el-form-item:nth-of-type(2) input', 'dusk-acme')
                 ->press('Save')
-                ->waitForTextIn('.el-message', 'Created', 10)
-                ->waitForTextIn('.el-table', 'dusk-acme', 10);
+                ->waitForTextIn('.el-message', 'Created', 20)
+                ->waitForTextIn('.el-table', 'dusk-acme', 20);
         });
     }
 
@@ -171,14 +174,23 @@ class SsoClientsPageTest extends DuskTestCase
             // test relies on dusk-acme existing from the previous test
             // (still disabled, per the above) and scopes to its row via an
             // XPath lookup rather than pressing the first global match for
-            // "Enable".
+            // "Enable". Poll first: the row exists as soon as the table
+            // renders, but WebDriver's findElement() below throws
+            // immediately (no implicit wait) if fired a beat too early.
+            $page->waitUsing(15, 100, function () use ($page) {
+                return (bool) $page->script(<<<'JS'
+                    return Array.from(document.querySelectorAll('.el-table__body-wrapper tbody tr'))
+                        .some(function (tr) { return tr.innerText.includes('dusk-acme'); });
+                JS)[0];
+            }, 'waiting for the dusk-acme row');
+
             $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'dusk-acme')]"));
 
             $row->findElement(WebDriverBy::xpath(".//button[contains(., 'Enable')]"))->click();
 
             $page->waitFor('.el-message-box', 10)
                 ->press('OK')
-                ->waitForTextIn('.el-message', 'enabled', 10);
+                ->waitForTextIn('.el-message', 'enabled', 20);
         });
     }
 
@@ -205,14 +217,14 @@ class SsoClientsPageTest extends DuskTestCase
             $this->clickVisibleDropdownOption($page, 'dev-sso@example.test');
 
             $page->press('Add')
-                ->waitForTextIn('.el-message', 'saved', 10)
-                ->waitForTextIn('.el-dialog', 'dev-sso@example.test', 10);
+                ->waitForTextIn('.el-message', 'saved', 20)
+                ->waitForTextIn('.el-dialog', 'dev-sso@example.test', 20);
 
             // Remove: close the tag via its "x" icon, which fires
             // removeGrant() -> saveGrants() again.
             $page->click('.el-dialog .el-tag .el-tag__close')
-                ->waitForTextIn('.el-message', 'saved', 10)
-                ->waitUntilMissingText('dev-sso@example.test', 10);
+                ->waitForTextIn('.el-message', 'saved', 20)
+                ->waitUntilMissingText('dev-sso@example.test', 20);
         });
     }
 }

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -39,47 +39,6 @@ class SsoClientsPageTest extends DuskTestCase
         SsoGrant::where('owner_type', 'organization')->where('owner_id', 933)->delete();
     }
 
-    /**
-     * Element UI appends a fresh `.el-select-dropdown` popper to <body> each
-     * time a select opens, but does not remove earlier ones from the DOM —
-     * they're just hidden. That makes plain-CSS selectors like
-     * `.el-select-dropdown__item` ambiguous (they can match a stale, hidden
-     * popper from an earlier interaction) and is why waitFor/waitForTextIn
-     * against that class flake here. Poll via JS for a *visible* dropdown
-     * item whose text contains $text — sidesteps both the multiple-popper
-     * ambiguity and the remote-search debounce race (an empty/loading
-     * popper rendering before the real result).
-     */
-    private function waitForVisibleDropdownOption(Browser $browser, string $text): Browser
-    {
-        $browser->waitUsing(10, 100, function () use ($browser, $text) {
-            return (bool) $browser->script(<<<JS
-                return Array.from(document.querySelectorAll('.el-select-dropdown__item')).some(function (el) {
-                    var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
-                    return visible && el.innerText.includes('{$text}');
-                });
-            JS)[0];
-        }, "waiting for a visible dropdown option containing \"{$text}\"");
-
-        return $browser;
-    }
-
-    private function clickVisibleDropdownOption(Browser $browser, string $text): Browser
-    {
-        $this->waitForVisibleDropdownOption($browser, $text);
-
-        $browser->script(<<<JS
-            var items = Array.from(document.querySelectorAll('.el-select-dropdown__item'));
-            var match = items.find(function (el) {
-                var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
-                return visible && el.innerText.includes('{$text}');
-            });
-            if (match) match.click();
-        JS);
-
-        return $browser;
-    }
-
     public function test_lists_the_seeded_client(): void
     {
         $this->browse(function (Browser $browser) {

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -35,6 +35,7 @@ class SsoClientsPageTest extends DuskTestCase
         // second `make dusk` run (without an intervening `make db`) hits
         // "slug already taken" and stale grant state from the previous run.
         SamlClient::where('slug', 'dusk-acme')->delete();
+        SamlClient::where('slug', 'dusk-system-acme')->delete();
         SsoGrant::where('owner_type', 'organization')->where('owner_id', 933)->delete();
     }
 
@@ -123,8 +124,11 @@ class SsoClientsPageTest extends DuskTestCase
             // Seeded org names contain "SSO"/"Dev" (e.g. "SSO Organization",
             // "Local Dev Organization") — there is no "Apex"-named org in the
             // local dev seed data, so search on a term that actually matches.
-            $page->click('.el-dialog .el-form-item:nth-of-type(3) .el-select input.el-input__inner')
-                ->type('.el-dialog .el-form-item:nth-of-type(3) .el-select input.el-input__inner', 'sso');
+            //
+            // Item order in create mode: 1=Name, 2=Slug, 3=Owned by (radio,
+            // added by the system-ownership feature), 4=Organization/System.
+            $page->click('.el-dialog .el-form-item:nth-of-type(4) .el-select input.el-input__inner')
+                ->type('.el-dialog .el-form-item:nth-of-type(4) .el-select input.el-input__inner', 'sso');
             $this->clickVisibleDropdownOption($page, 'SSO Organization');
 
             // Duplicate slug -> inline error from the field-errors bag.
@@ -143,6 +147,48 @@ class SsoClientsPageTest extends DuskTestCase
         });
     }
 
+    public function test_create_system_owned_client(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitPage($browser);
+
+            $page->press('New client')
+                ->waitFor('.el-dialog', 10)
+                ->type('.el-dialog .el-form-item:nth-of-type(1) input', 'Dusk System Acme')
+                ->type('.el-dialog .el-form-item:nth-of-type(2) input', 'dusk-system-acme');
+
+            // Owned by: switch to System. Item order in create mode:
+            // 1=Name, 2=Slug, 3=Owned by, 4=System (once selected).
+            $page->click('.el-dialog .el-form-item:nth-of-type(3) label:nth-of-type(2)');
+
+            // System picker: remote-search select, same idiom as the org
+            // picker in the org-owned create test above.
+            $page->click('.el-dialog .el-form-item:nth-of-type(4) .el-select input.el-input__inner')
+                ->type('.el-dialog .el-form-item:nth-of-type(4) .el-select input.el-input__inner', 'Local');
+            $this->clickVisibleDropdownOption($page, 'Local Health System');
+
+            // System-owned clients cannot hold a default department — the
+            // form must not render that field at all once System is chosen.
+            $page->assertMissing('.el-dialog .el-form-item:nth-of-type(5) .el-select[placeholder="Select a department"]');
+            $page->assertDontSeeIn('.el-dialog', 'Default department');
+
+            $page->press('Save')
+                ->waitForTextIn('.el-message', 'Created', 20)
+                ->waitForTextIn('.el-table', 'dusk-system-acme', 20);
+
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'dusk-system-acme')]"));
+
+            $this->assertStringContainsString('Local Health System', $row->getText());
+            $this->assertStringContainsString('system', $row->getText());
+
+            $this->assertDatabaseHas('saml_clients', [
+                'slug' => 'dusk-system-acme',
+                'owner_type' => 'system',
+                'owner_id' => 1,
+            ]);
+        });
+    }
+
     public function test_department_dropdown_follows_org(): void
     {
         $this->browse(function (Browser $browser) {
@@ -150,8 +196,10 @@ class SsoClientsPageTest extends DuskTestCase
 
             // Edit local-idp (org 933) — department select must offer its
             // departments plus the "no department" option. In edit mode the
-            // Slug form-item is hidden (v-if="!editSlug"), so the item order
-            // shifts: 1=Name, 2=Organization, 3=Department.
+            // Slug form-item is hidden (v-if="!editSlug"), and the "Owned by"
+            // radio (added by the system-ownership feature) is shown but
+            // disabled, so the item order is: 1=Name, 2=Owned by,
+            // 3=Organization, 4=Department.
             //
             // The table sorts by name and dusk-acme sorts before local-idp,
             // so ":first-child" is NOT local-idp's row — scope to it by
@@ -162,7 +210,7 @@ class SsoClientsPageTest extends DuskTestCase
             $row->click();
 
             $page->waitFor('.el-dialog', 10)
-                ->click('.el-dialog .el-form-item:nth-of-type(3) .el-select');
+                ->click('.el-dialog .el-form-item:nth-of-type(4) .el-select');
 
             $this->waitForVisibleDropdownOption($page, 'None — users choose at finish-account');
 

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\Browser\Support\InteractsWithAdminPortal;
+use Tests\DuskTestCase;
+
+class SsoClientsPageTest extends DuskTestCase
+{
+    use InteractsWithAdminPortal;
+
+    private function visitPage(Browser $browser): Browser
+    {
+        $this->loginAsPortalAdmin($browser);
+
+        return $browser->visit(env('DUSK_ADMIN_URL', 'http://localhost/admin').'/SSOClients.php')
+            ->waitFor('#ssoClients tbody tr', 10);
+    }
+
+    public function test_lists_the_seeded_client(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $this->visitPage($browser)
+                ->assertSeeIn('#ssoClients', 'local-idp')
+                ->assertSeeIn('#ssoClients', 'example.com');
+        });
+    }
+
+    public function test_create_shows_validation_errors_then_succeeds(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitPage($browser);
+
+            // Duplicate slug -> inline 422 field error from the API's bag
+            $page->type('name', 'Dupe')
+                ->type('slug', 'local-idp')
+                ->type('organization_id', '933')
+                ->press('Save')
+                ->waitForTextIn('.fieldError[data-for=slug]', 'taken', 10);
+
+            // Unique slug -> created, appears in the table, detail panel opens
+            $page->type('slug', 'dusk-acme')
+                ->type('[name=email_domains]', 'dusk-acme.test')
+                ->press('Save')
+                ->waitForTextIn('#saveMsg', 'Created', 10)
+                // loadClients() re-renders the table asynchronously after
+                // the "Created" message is set (a separate `list` request),
+                // so wait for the new row rather than asserting immediately.
+                ->waitForTextIn('#ssoClients', 'dusk-acme', 10)
+                ->assertVisible('#detailPanel');
+        });
+    }
+
+    public function test_enable_disable_round_trip(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitPage($browser);
+
+            $row = '#ssoClients tr[data-slug=dusk-acme]';
+            $page->click($row.' .toggleClient')
+                ->acceptDialog()
+                ->waitForTextIn('#saveMsg', 'enabled', 10);
+        });
+    }
+
+    public function test_grants_panel_adds_and_removes(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitPage($browser);
+
+            // local-idp's org is 933; dev-sso@example.test belongs to it via
+            // seeding (DepartmentID 3 -> SSO Department -> Organization 933).
+            // dev@example.test does NOT belong to org 933 (its department is
+            // a randomly-factoried one), so it can't be used here — the
+            // grants API rejects logins whose department doesn't match the
+            // client's organization_id (SsoGrantController::replace).
+            $page->click('#ssoClients tr[data-slug=local-idp] .editClient')
+                ->waitFor('#detailPanel', 10)
+                ->type('#grantLogin', 'dev-sso@example.test')
+                ->click('#addGrant')
+                ->waitForTextIn('#grantsList', 'dev-sso@example.test', 10)
+                ->click('#grantsList .removeGrant')
+                ->waitUntilMissingText('dev-sso@example.test', 10);
+        });
+    }
+}

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -152,8 +152,16 @@ class SsoClientsPageTest extends DuskTestCase
             // departments plus the "no department" option. In edit mode the
             // Slug form-item is hidden (v-if="!editSlug"), so the item order
             // shifts: 1=Name, 2=Organization, 3=Department.
-            $page->click('.el-table__body-wrapper tbody tr:first-child')
-                ->waitFor('.el-dialog', 10)
+            //
+            // The table sorts by name and dusk-acme sorts before local-idp,
+            // so ":first-child" is NOT local-idp's row — scope to it by
+            // slug via the same XPath row-lookup the enable/disable test
+            // below uses, rather than positional selection.
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'local-idp')]"));
+
+            $row->click();
+
+            $page->waitFor('.el-dialog', 10)
                 ->click('.el-dialog .el-form-item:nth-of-type(3) .el-select');
 
             $this->waitForVisibleDropdownOption($page, 'None — users choose at finish-account');
@@ -206,6 +214,14 @@ class SsoClientsPageTest extends DuskTestCase
             // local-idp's org is 933; dev-sso@example.test belongs to it via
             // seeding, so it's a valid grantee for local-idp's client.
             //
+            // The table sorts by name and dusk-acme sorts before local-idp,
+            // so ":first-child" is NOT local-idp's row — scope to it by
+            // slug via the same XPath row-lookup the enable/disable test
+            // uses, rather than positional selection.
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'local-idp')]"));
+
+            $row->click();
+
             // The form-level size="small" cascades to every el-select in the
             // dialog (organization AND department pickers also render
             // `.el-select--small`), so that class alone doesn't uniquely
@@ -213,8 +229,7 @@ class SsoClientsPageTest extends DuskTestCase
             // placeholder instead.
             $grantInput = '.el-dialog .el-select input.el-input__inner[placeholder="Search users by name or email"]';
 
-            $page->click('.el-table__body-wrapper tbody tr:first-child')
-                ->waitFor('.el-dialog', 10)
+            $page->waitFor('.el-dialog', 10)
                 ->click($grantInput)
                 ->type($grantInput, 'dev-sso');
 
@@ -225,8 +240,12 @@ class SsoClientsPageTest extends DuskTestCase
                 ->waitForTextIn('.el-dialog', 'dev-sso@example.test', 20);
 
             // Remove: close the tag via its "x" icon, which fires
-            // removeGrant() -> saveGrants() again.
-            $page->click('.el-dialog .el-tag .el-tag__close')
+            // removeGrant() -> saveGrants() again. Scope to grant tags
+            // specifically (class hook added in SSOClientsApp.vue) — the
+            // dialog also renders el-tags for email domains, and a bare
+            // `.el-tag .el-tag__close` selector would ambiguously match
+            // those too.
+            $page->click('.el-dialog .grant-tag .el-tag__close')
                 ->waitForTextIn('.el-message', 'saved', 20)
                 ->waitUntilMissingText('dev-sso@example.test', 20);
         });

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -35,7 +35,7 @@ class SsoClientsPageTest extends DuskTestCase
         // second `make dusk` run (without an intervening `make db`) hits
         // "slug already taken" and stale grant state from the previous run.
         SamlClient::where('slug', 'dusk-acme')->delete();
-        SsoGrant::where('organization_id', 933)->delete();
+        SsoGrant::where('owner_type', 'organization')->where('owner_id', 933)->delete();
     }
 
     /**

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -40,28 +40,6 @@ class SsoClientsPageTest extends DuskTestCase
     }
 
     /**
-     * The legacy portal intermittently serves a truncated response for this
-     * page under Selenium (observed: HEADER.php's admin-employee lookup
-     * throws "table doesn't exist" against the shared MySQL container,
-     * unrelated to anything the SSO client feature touches, then falls
-     * through to a short error/unauthorized page instead of the Vue-mounted
-     * one) — reload once if the table never shows up rather than let one
-     * infra blip fail an otherwise-passing test.
-     */
-    private function visitPage(Browser $browser): Browser
-    {
-        $this->loginAsPortalAdmin($browser);
-
-        $url = env('DUSK_ADMIN_URL', 'http://localhost/admin').'/SSOClients.php';
-
-        try {
-            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
-        } catch (\Throwable $e) {
-            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
-        }
-    }
-
-    /**
      * Element UI appends a fresh `.el-select-dropdown` popper to <body> each
      * time a select opens, but does not remove earlier ones from the DOM —
      * they're just hidden. That makes plain-CSS selectors like
@@ -105,7 +83,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_lists_the_seeded_client(): void
     {
         $this->browse(function (Browser $browser) {
-            $this->visitPage($browser)
+            $this->visitSsoClientsPage($browser)
                 ->assertSeeIn('.el-table', 'local-idp')
                 ->assertSeeIn('.el-table', 'example.com');
         });
@@ -114,7 +92,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_create_with_org_picker_and_validation(): void
     {
         $this->browse(function (Browser $browser) {
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             $page->press('New client')
                 ->waitFor('.el-dialog', 10)
@@ -150,7 +128,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_create_system_owned_client(): void
     {
         $this->browse(function (Browser $browser) {
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             $page->press('New client')
                 ->waitFor('.el-dialog', 10)
@@ -191,7 +169,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_department_dropdown_follows_org(): void
     {
         $this->browse(function (Browser $browser) {
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             // Edit local-idp (org 933) — department select must offer its
             // departments plus the "no department" option. In edit mode the
@@ -224,7 +202,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_enable_disable_round_trip(): void
     {
         $this->browse(function (Browser $browser) {
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             // New clients are created disabled (SamlClientManager::create
             // forces enabled=false until IdP metadata is applied), while
@@ -256,7 +234,7 @@ class SsoClientsPageTest extends DuskTestCase
     public function test_grants_panel_adds_and_removes(): void
     {
         $this->browse(function (Browser $browser) {
-            $page = $this->visitPage($browser);
+            $page = $this->visitSsoClientsPage($browser);
 
             // local-idp's org is 933; dev-sso@example.test belongs to it via
             // seeding, so it's a valid grantee for local-idp's client.

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -169,7 +169,6 @@ class SsoClientsPageTest extends DuskTestCase
 
             // System-owned clients cannot hold a default department — the
             // form must not render that field at all once System is chosen.
-            $page->assertMissing('.el-dialog .el-form-item:nth-of-type(5) .el-select[placeholder="Select a department"]');
             $page->assertDontSeeIn('.el-dialog', 'Default department');
 
             $page->press('Save')

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Browser;
 
+use App\Models\SamlClient;
+use App\Models\SsoGrant;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Support\InteractsWithAdminPortal;
 use Tests\DuskTestCase;
@@ -9,6 +11,31 @@ use Tests\DuskTestCase;
 class SsoClientsPageTest extends DuskTestCase
 {
     use InteractsWithAdminPortal;
+
+    /**
+     * Tracks whether the once-per-class cleanup below has already run, so
+     * later test methods in this class don't wipe state that an earlier
+     * test method in the same run just created (e.g. "dusk-acme").
+     */
+    private static bool $cleanedStaleState = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (self::$cleanedStaleState) {
+            return;
+        }
+
+        self::$cleanedStaleState = true;
+
+        // Idempotency: these tests create/mutate a "dusk-acme" client and
+        // grants on org 933 (local-idp's org). Without this cleanup, a
+        // second `make dusk` run (without an intervening `make db`) hits
+        // "slug already taken" and stale grant state from the previous run.
+        SamlClient::where('slug', 'dusk-acme')->delete();
+        SsoGrant::where('organization_id', 933)->delete();
+    }
 
     private function visitPage(Browser $browser): Browser
     {

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -4,6 +4,7 @@ namespace Tests\Browser;
 
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
+use Facebook\WebDriver\WebDriverBy;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Support\InteractsWithAdminPortal;
 use Tests\DuskTestCase;
@@ -37,45 +38,124 @@ class SsoClientsPageTest extends DuskTestCase
         SsoGrant::where('organization_id', 933)->delete();
     }
 
+    /**
+     * The legacy portal intermittently serves a truncated response for this
+     * page under Selenium (observed: HEADER.php's admin-employee lookup
+     * throws "table doesn't exist" against the shared MySQL container,
+     * unrelated to anything the SSO client feature touches, then falls
+     * through to a short error/unauthorized page instead of the Vue-mounted
+     * one) — reload once if the table never shows up rather than let one
+     * infra blip fail an otherwise-passing test.
+     */
     private function visitPage(Browser $browser): Browser
     {
         $this->loginAsPortalAdmin($browser);
 
-        return $browser->visit(env('DUSK_ADMIN_URL', 'http://localhost/admin').'/SSOClients.php')
-            ->waitFor('#ssoClients tbody tr', 10);
+        $url = env('DUSK_ADMIN_URL', 'http://localhost/admin').'/SSOClients.php';
+
+        try {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        } catch (\Throwable $e) {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        }
+    }
+
+    /**
+     * Element UI appends a fresh `.el-select-dropdown` popper to <body> each
+     * time a select opens, but does not remove earlier ones from the DOM —
+     * they're just hidden. That makes plain-CSS selectors like
+     * `.el-select-dropdown__item` ambiguous (they can match a stale, hidden
+     * popper from an earlier interaction) and is why waitFor/waitForTextIn
+     * against that class flake here. Poll via JS for a *visible* dropdown
+     * item whose text contains $text — sidesteps both the multiple-popper
+     * ambiguity and the remote-search debounce race (an empty/loading
+     * popper rendering before the real result).
+     */
+    private function waitForVisibleDropdownOption(Browser $browser, string $text): Browser
+    {
+        $browser->waitUsing(10, 100, function () use ($browser, $text) {
+            return (bool) $browser->script(<<<JS
+                return Array.from(document.querySelectorAll('.el-select-dropdown__item')).some(function (el) {
+                    var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+                    return visible && el.innerText.includes('{$text}');
+                });
+            JS)[0];
+        }, "waiting for a visible dropdown option containing \"{$text}\"");
+
+        return $browser;
+    }
+
+    private function clickVisibleDropdownOption(Browser $browser, string $text): Browser
+    {
+        $this->waitForVisibleDropdownOption($browser, $text);
+
+        $browser->script(<<<JS
+            var items = Array.from(document.querySelectorAll('.el-select-dropdown__item'));
+            var match = items.find(function (el) {
+                var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+                return visible && el.innerText.includes('{$text}');
+            });
+            if (match) match.click();
+        JS);
+
+        return $browser;
     }
 
     public function test_lists_the_seeded_client(): void
     {
         $this->browse(function (Browser $browser) {
             $this->visitPage($browser)
-                ->assertSeeIn('#ssoClients', 'local-idp')
-                ->assertSeeIn('#ssoClients', 'example.com');
+                ->assertSeeIn('.el-table', 'local-idp')
+                ->assertSeeIn('.el-table', 'example.com');
         });
     }
 
-    public function test_create_shows_validation_errors_then_succeeds(): void
+    public function test_create_with_org_picker_and_validation(): void
     {
         $this->browse(function (Browser $browser) {
             $page = $this->visitPage($browser);
 
-            // Duplicate slug -> inline 422 field error from the API's bag
-            $page->type('name', 'Dupe')
-                ->type('slug', 'local-idp')
-                ->type('organization_id', '933')
-                ->press('Save')
-                ->waitForTextIn('.fieldError[data-for=slug]', 'taken', 10);
+            $page->press('New client')
+                ->waitFor('.el-dialog', 10)
+                ->type('.el-dialog .el-form-item:nth-of-type(1) input', 'Dusk Acme');
 
-            // Unique slug -> created, appears in the table, detail panel opens
-            $page->type('slug', 'dusk-acme')
-                ->type('[name=email_domains]', 'dusk-acme.test')
+            // Org picker: remote-search select — type, wait for a result, choose it.
+            // Seeded org names contain "SSO"/"Dev" (e.g. "SSO Organization",
+            // "Local Dev Organization") — there is no "Apex"-named org in the
+            // local dev seed data, so search on a term that actually matches.
+            $page->click('.el-dialog .el-form-item:nth-of-type(3) .el-select input.el-input__inner')
+                ->type('.el-dialog .el-form-item:nth-of-type(3) .el-select input.el-input__inner', 'sso');
+            $this->clickVisibleDropdownOption($page, 'SSO Organization');
+
+            // Duplicate slug -> inline error from the field-errors bag.
+            $page->type('.el-dialog .el-form-item:nth-of-type(2) input', 'local-idp')
                 ->press('Save')
-                ->waitForTextIn('#saveMsg', 'Created', 10)
-                // loadClients() re-renders the table asynchronously after
-                // the "Created" message is set (a separate `list` request),
-                // so wait for the new row rather than asserting immediately.
-                ->waitForTextIn('#ssoClients', 'dusk-acme', 10)
-                ->assertVisible('#detailPanel');
+                ->waitFor('.el-form-item__error', 10);
+
+            // Unique slug -> created.
+            $page->type('.el-dialog .el-form-item:nth-of-type(2) input', 'dusk-acme')
+                ->press('Save')
+                ->waitForTextIn('.el-message', 'Created', 10)
+                ->waitForTextIn('.el-table', 'dusk-acme', 10);
+        });
+    }
+
+    public function test_department_dropdown_follows_org(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $page = $this->visitPage($browser);
+
+            // Edit local-idp (org 933) — department select must offer its
+            // departments plus the "no department" option. In edit mode the
+            // Slug form-item is hidden (v-if="!editSlug"), so the item order
+            // shifts: 1=Name, 2=Organization, 3=Department.
+            $page->click('.el-table__body-wrapper tbody tr:first-child')
+                ->waitFor('.el-dialog', 10)
+                ->click('.el-dialog .el-form-item:nth-of-type(3) .el-select');
+
+            $this->waitForVisibleDropdownOption($page, 'None — users choose at finish-account');
+
+            $page->assertSee('None — users choose at finish-account');
         });
     }
 
@@ -84,10 +164,21 @@ class SsoClientsPageTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $page = $this->visitPage($browser);
 
-            $row = '#ssoClients tr[data-slug=dusk-acme]';
-            $page->click($row.' .toggleClient')
-                ->acceptDialog()
-                ->waitForTextIn('#saveMsg', 'enabled', 10);
+            // New clients are created disabled (SamlClientManager::create
+            // forces enabled=false until IdP metadata is applied), while
+            // `make db` explicitly enables local-idp — so both "Enable" and
+            // "Disable" button text exist on the page simultaneously. This
+            // test relies on dusk-acme existing from the previous test
+            // (still disabled, per the above) and scopes to its row via an
+            // XPath lookup rather than pressing the first global match for
+            // "Enable".
+            $row = $page->driver->findElement(WebDriverBy::xpath("//tr[contains(., 'dusk-acme')]"));
+
+            $row->findElement(WebDriverBy::xpath(".//button[contains(., 'Enable')]"))->click();
+
+            $page->waitFor('.el-message-box', 10)
+                ->press('OK')
+                ->waitForTextIn('.el-message', 'enabled', 10);
         });
     }
 
@@ -97,17 +188,30 @@ class SsoClientsPageTest extends DuskTestCase
             $page = $this->visitPage($browser);
 
             // local-idp's org is 933; dev-sso@example.test belongs to it via
-            // seeding (DepartmentID 3 -> SSO Department -> Organization 933).
-            // dev@example.test does NOT belong to org 933 (its department is
-            // a randomly-factoried one), so it can't be used here — the
-            // grants API rejects logins whose department doesn't match the
-            // client's organization_id (SsoGrantController::replace).
-            $page->click('#ssoClients tr[data-slug=local-idp] .editClient')
-                ->waitFor('#detailPanel', 10)
-                ->type('#grantLogin', 'dev-sso@example.test')
-                ->click('#addGrant')
-                ->waitForTextIn('#grantsList', 'dev-sso@example.test', 10)
-                ->click('#grantsList .removeGrant')
+            // seeding, so it's a valid grantee for local-idp's client.
+            //
+            // The form-level size="small" cascades to every el-select in the
+            // dialog (organization AND department pickers also render
+            // `.el-select--small`), so that class alone doesn't uniquely
+            // identify the grants search box — target it by its distinct
+            // placeholder instead.
+            $grantInput = '.el-dialog .el-select input.el-input__inner[placeholder="Search users by name or email"]';
+
+            $page->click('.el-table__body-wrapper tbody tr:first-child')
+                ->waitFor('.el-dialog', 10)
+                ->click($grantInput)
+                ->type($grantInput, 'dev-sso');
+
+            $this->clickVisibleDropdownOption($page, 'dev-sso@example.test');
+
+            $page->press('Add')
+                ->waitForTextIn('.el-message', 'saved', 10)
+                ->waitForTextIn('.el-dialog', 'dev-sso@example.test', 10);
+
+            // Remove: close the tag via its "x" icon, which fires
+            // removeGrant() -> saveGrants() again.
+            $page->click('.el-dialog .el-tag .el-tag__close')
+                ->waitForTextIn('.el-message', 'saved', 10)
                 ->waitUntilMissingText('dev-sso@example.test', 10);
         });
     }

--- a/tests/Browser/SsoClientsPageTest.php
+++ b/tests/Browser/SsoClientsPageTest.php
@@ -159,6 +159,10 @@ class SsoClientsPageTest extends DuskTestCase
             $this->waitForVisibleDropdownOption($page, 'None — users choose at finish-account');
 
             $page->assertSee('None — users choose at finish-account');
+
+            $this->waitForVisibleDropdownOption($page, 'SSO Department');
+
+            $page->assertSee('SSO Department');
         });
     }
 

--- a/tests/Browser/Support/InteractsWithAdminPortal.php
+++ b/tests/Browser/Support/InteractsWithAdminPortal.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Browser\Support;
+
+use Laravel\Dusk\Browser;
+
+trait InteractsWithAdminPortal
+{
+    /**
+     * Log into the legacy admin portal (HEADER.php renders the login form
+     * inline when no AdminID is in session). Requires make db state
+     * (LocalEmployeeSeeder).
+     *
+     * HEADER.php's login form (website_admin/HEADER.php:138-158) has no
+     * `name`/`id` on its submit button, only value="Login" — Dusk's
+     * press() matches on value, so we press('Login') rather than the
+     * form's id ("Logon").
+     *
+     * Lands on Home.php rather than AdminPreferences.php: the latter's
+     * "not authorized" branch triggers whenever the `?ID=` query param is
+     * absent, regardless of login state (website_admin/AdminPreferences.php:9),
+     * so it can't distinguish "not logged in" from "no ID given". Home.php's
+     * only gate is $_SESSION['AdminID'].
+     */
+    protected function loginAsPortalAdmin(Browser $browser): Browser
+    {
+        $browser->visit(env('DUSK_ADMIN_URL', 'http://localhost/admin').'/Home.php');
+
+        if ($browser->element('input[name=Username]')) {
+            $browser->type('Username', 'dev.admin')
+                ->type('Password', 'password')
+                ->press('Login')
+                ->pause(500);
+        }
+
+        return $browser;
+    }
+}

--- a/tests/Browser/Support/InteractsWithAdminPortal.php
+++ b/tests/Browser/Support/InteractsWithAdminPortal.php
@@ -38,4 +38,26 @@ trait InteractsWithAdminPortal
 
         return $browser;
     }
+
+    /**
+     * The legacy portal intermittently serves a truncated response for this
+     * page under Selenium (observed: HEADER.php's admin-employee lookup
+     * throws "table doesn't exist" against the shared MySQL container,
+     * unrelated to anything the SSO client feature touches, then falls
+     * through to a short error/unauthorized page instead of the Vue-mounted
+     * one) — reload once if the table never shows up rather than let one
+     * infra blip fail an otherwise-passing test.
+     */
+    protected function visitSsoClientsPage(Browser $browser): Browser
+    {
+        $this->loginAsPortalAdmin($browser);
+
+        $url = env('DUSK_ADMIN_URL', 'http://localhost/admin').'/SSOClients.php';
+
+        try {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        } catch (\Throwable $e) {
+            return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
+        }
+    }
 }

--- a/tests/Browser/Support/InteractsWithAdminPortal.php
+++ b/tests/Browser/Support/InteractsWithAdminPortal.php
@@ -30,7 +30,10 @@ trait InteractsWithAdminPortal
             $browser->type('Username', 'dev.admin')
                 ->type('Password', 'password')
                 ->press('Login')
-                ->pause(500);
+                // Home.php only renders #adminID once $_SESSION['AdminID'] is
+                // set, so this is a stable signal that login completed
+                // (rather than a fixed pause guessing how long that takes).
+                ->waitFor('#adminID', 10);
         }
 
         return $browser;

--- a/tests/Browser/Support/InteractsWithAdminPortal.php
+++ b/tests/Browser/Support/InteractsWithAdminPortal.php
@@ -60,4 +60,45 @@ trait InteractsWithAdminPortal
             return $browser->visit($url)->waitFor('.el-table__body-wrapper tbody tr', 15);
         }
     }
+
+    /**
+     * Element UI appends a fresh `.el-select-dropdown` popper to <body> each
+     * time a select opens, but does not remove earlier ones from the DOM —
+     * they're just hidden. That makes plain-CSS selectors like
+     * `.el-select-dropdown__item` ambiguous (they can match a stale, hidden
+     * popper from an earlier interaction) and is why waitFor/waitForTextIn
+     * against that class flake here. Poll via JS for a *visible* dropdown
+     * item whose text contains $text — sidesteps both the multiple-popper
+     * ambiguity and the remote-search debounce race (an empty/loading
+     * popper rendering before the real result).
+     */
+    protected function waitForVisibleDropdownOption(Browser $browser, string $text): Browser
+    {
+        $browser->waitUsing(10, 100, function () use ($browser, $text) {
+            return (bool) $browser->script(<<<JS
+                return Array.from(document.querySelectorAll('.el-select-dropdown__item')).some(function (el) {
+                    var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+                    return visible && el.innerText.includes('{$text}');
+                });
+            JS)[0];
+        }, "waiting for a visible dropdown option containing \"{$text}\"");
+
+        return $browser;
+    }
+
+    protected function clickVisibleDropdownOption(Browser $browser, string $text): Browser
+    {
+        $this->waitForVisibleDropdownOption($browser, $text);
+
+        $browser->script(<<<JS
+            var items = Array.from(document.querySelectorAll('.el-select-dropdown__item'));
+            var match = items.find(function (el) {
+                var visible = !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+                return visible && el.innerText.includes('{$text}');
+            });
+            if (match) match.click();
+        JS);
+
+        return $browser;
+    }
 }

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests;
+
+use Facebook\WebDriver\Chrome\ChromeOptions;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Laravel\Dusk\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\BeforeClass;
+
+abstract class DuskTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Prepare for Dusk test execution.
+     *
+     * We connect to the standalone selenium/standalone-chrome container
+     * (see docker-compose.yml) over the network rather than starting a local
+     * chromedriver binary, so there is nothing to prepare here.
+     */
+    #[BeforeClass]
+    public static function prepare(): void
+    {
+        //
+    }
+
+    /**
+     * Create the RemoteWebDriver instance.
+     */
+    protected function driver(): RemoteWebDriver
+    {
+        $options = (new ChromeOptions)->addArguments([
+            '--headless=new',
+            '--disable-gpu',
+            '--window-size=1920,1080',
+        ]);
+
+        return RemoteWebDriver::create(
+            env('DUSK_DRIVER_URL', 'http://host.docker.internal:4444/wd/hub'),
+            DesiredCapabilities::chrome()->setCapability(ChromeOptions::CAPABILITY, $options)
+        );
+    }
+}

--- a/tests/Feature/AdminApiSsoHandoffTest.php
+++ b/tests/Feature/AdminApiSsoHandoffTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdminApiSsoHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // Alphabetically the first RefreshDatabase class in the suite, so it
+    // decides whether the one-time migrate:fresh seeds. $seed = true keeps
+    // the suite-wide seed pass alive (see ReferenceDataSeederTest's note).
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['admin.api_token' => 'test-token', 'saml.replay_store' => 'array',
+            'saml.admin_portal_url' => 'http://localhost/admin']);
+    }
+
+    private function authHeaders(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+    }
+
+    private function mintToken(): string
+    {
+        DB::table('Employees')->insert([
+            'Email' => 'jane@apexinnovations.com', 'FirstName' => 'Jane', 'LastName' => 'Doe',
+            'Password' => md5('p6^8&x'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+
+        $client = SamlClient::factory()->adminPortal()->create();
+        $url = app(AdminSsoHandoff::class)->initiate($client, 'jane@apexinnovations.com');
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+        return $query['token'];
+    }
+
+    public function test_token_redeems_exactly_once(): void
+    {
+        $token = $this->mintToken();
+
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => $token], $this->authHeaders())
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Jane Doe');
+
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => $token], $this->authHeaders())
+            ->assertNotFound();
+    }
+
+    public function test_unknown_token_404s(): void
+    {
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => 'nope'], $this->authHeaders())
+            ->assertNotFound();
+    }
+
+    public function test_requires_admin_token(): void
+    {
+        $this->postJson('/api/admin/sso-handoff/redeem', ['token' => 'anything'])
+            ->assertUnauthorized();
+    }
+}

--- a/tests/Feature/AdminApiSsoHandoffTest.php
+++ b/tests/Feature/AdminApiSsoHandoffTest.php
@@ -6,10 +6,12 @@ use App\Models\SamlClient;
 use App\Saml\AdminSsoHandoff;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminApiSsoHandoffTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     // Alphabetically the first RefreshDatabase class in the suite, so it
@@ -21,13 +23,13 @@ class AdminApiSsoHandoffTest extends TestCase
     {
         parent::setUp();
 
-        config(['admin.api_token' => 'test-token', 'saml.replay_store' => 'array',
-            'saml.admin_portal_url' => 'http://localhost/admin']);
+        $this->configureAdminApi();
+        config(['saml.replay_store' => 'array', 'saml.admin_portal_url' => 'http://localhost/admin']);
     }
 
     private function authHeaders(): array
     {
-        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+        return $this->adminApiHeaders();
     }
 
     private function mintToken(): string

--- a/tests/Feature/AdminApiTokenTest.php
+++ b/tests/Feature/AdminApiTokenTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class AdminApiTokenTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(['api', 'admin.api'])->prefix('api/admin-probe')->group(function () {
+            Route::get('/ping', fn () => response()->json(['pong' => true]));
+            Route::post('/ping', fn () => response()->json(['pong' => true]));
+        });
+    }
+
+    public function test_unconfigured_token_returns_503(): void
+    {
+        config(['admin.api_token' => null]);
+
+        $this->getJson('/api/admin-probe/ping', ['Authorization' => 'Bearer anything'])
+            ->assertStatus(503);
+    }
+
+    public function test_missing_or_wrong_token_returns_401(): void
+    {
+        config(['admin.api_token' => 'test-token']);
+
+        $this->getJson('/api/admin-probe/ping')->assertStatus(401);
+        $this->getJson('/api/admin-probe/ping', ['Authorization' => 'Bearer nope'])->assertStatus(401);
+    }
+
+    public function test_mutation_without_acting_admin_returns_400(): void
+    {
+        config(['admin.api_token' => 'test-token']);
+
+        $this->postJson('/api/admin-probe/ping', [], ['Authorization' => 'Bearer test-token'])
+            ->assertStatus(400);
+    }
+
+    public function test_valid_requests_pass(): void
+    {
+        config(['admin.api_token' => 'test-token']);
+
+        $this->getJson('/api/admin-probe/ping', ['Authorization' => 'Bearer test-token'])
+            ->assertOk()->assertJson(['pong' => true]);
+
+        $this->postJson('/api/admin-probe/ping', [], [
+            'Authorization' => 'Bearer test-token',
+            'X-Acting-Admin' => '1:Test Admin',
+        ])->assertOk();
+    }
+}

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -107,6 +107,7 @@ class AdminLookupTest extends TestCase
             '/api/admin/organizations',
             "/api/admin/organizations/{$org->ID}/departments",
             "/api/admin/saml-clients/{$client->slug}/users",
+            '/api/admin/systems',
         ];
 
         foreach ($routes as $route) {

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -112,5 +113,17 @@ class AdminLookupTest extends TestCase
             $this->getJson($route)->assertUnauthorized();
             $this->getJson($route, ['Authorization' => 'Bearer wrong-token'])->assertUnauthorized();
         }
+    }
+
+    public function test_systems_lookup_searches_by_name(): void
+    {
+        $system = System::factory()->create(['Name' => 'Mercy Health System']);
+        System::factory()->create(['Name' => 'Other']);
+
+        $this->getJson('/api/admin/systems?q=mercy', $this->headers())
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $system->ID)
+            ->assertJsonPath('data.0.name', 'Mercy Health System');
     }
 }

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -7,6 +7,7 @@ use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class AdminLookupTest extends TestCase
@@ -83,5 +84,33 @@ class AdminLookupTest extends TestCase
     public function test_departments_non_numeric_organization_404s(): void
     {
         $this->getJson('/api/admin/organizations/not-a-number/departments', $this->headers())->assertNotFound();
+    }
+
+    public function test_organization_search_is_limited_to_25_results(): void
+    {
+        for ($i = 0; $i < 30; $i++) {
+            Organization::factory()->create(['Name' => 'Prefix Org '.Str::random(6)]);
+        }
+
+        $response = $this->getJson('/api/admin/organizations?q=Prefix Org', $this->headers())->assertOk();
+
+        $this->assertCount(25, $response->json('data'));
+    }
+
+    public function test_lookup_routes_require_a_valid_token(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'organization_id' => $org->ID]);
+
+        $routes = [
+            '/api/admin/organizations',
+            "/api/admin/organizations/{$org->ID}/departments",
+            "/api/admin/saml-clients/{$client->slug}/users",
+        ];
+
+        foreach ($routes as $route) {
+            $this->getJson($route)->assertUnauthorized();
+            $this->getJson($route, ['Authorization' => 'Bearer wrong-token'])->assertUnauthorized();
+        }
     }
 }

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -57,7 +57,7 @@ class AdminLookupTest extends TestCase
     public function test_user_search_scoped_to_client_org_matches_login_and_name(): void
     {
         $dept = Department::factory()->create();
-        $client = SamlClient::factory()->create(['slug' => 'acme', 'organization_id' => $dept->OrganizationID]);
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $dept->OrganizationID]);
         User::factory()->create(['Login' => 'jane@acme.com', 'FirstName' => 'Jane', 'LastName' => 'Smith', 'DepartmentID' => $dept->ID]);
         $otherDept = Department::factory()->create();
         User::factory()->create(['Login' => 'jane@other.com', 'FirstName' => 'Jane', 'LastName' => 'Elsewhere', 'DepartmentID' => $otherDept->ID]);
@@ -100,7 +100,7 @@ class AdminLookupTest extends TestCase
     public function test_lookup_routes_require_a_valid_token(): void
     {
         $org = Organization::factory()->create();
-        $client = SamlClient::factory()->create(['slug' => 'acme', 'organization_id' => $org->ID]);
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $org->ID]);
 
         $routes = [
             '/api/admin/organizations',

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -74,4 +74,14 @@ class AdminLookupTest extends TestCase
     {
         $this->getJson('/api/admin/saml-clients/nope/users?q=x', $this->headers())->assertNotFound();
     }
+
+    public function test_departments_unknown_organization_404s(): void
+    {
+        $this->getJson('/api/admin/organizations/999999/departments', $this->headers())->assertNotFound();
+    }
+
+    public function test_departments_non_numeric_organization_404s(): void
+    {
+        $this->getJson('/api/admin/organizations/not-a-number/departments', $this->headers())->assertNotFound();
+    }
 }

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -9,23 +9,25 @@ use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminLookupTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     protected $seed = true;
 
     private function headers(): array
     {
-        return ['Authorization' => 'Bearer test-token'];
+        return $this->adminApiHeaders(actingAdmin: null);
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        config(['admin.api_token' => 'test-token']);
+        $this->configureAdminApi();
     }
 
     public function test_organization_search_filters_by_name(): void

--- a/tests/Feature/AdminLookupTest.php
+++ b/tests/Feature/AdminLookupTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminLookupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function headers(): array
+    {
+        return ['Authorization' => 'Bearer test-token'];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['admin.api_token' => 'test-token']);
+    }
+
+    public function test_organization_search_filters_by_name(): void
+    {
+        Organization::factory()->create(['Name' => 'Memorial Hermann']);
+        Organization::factory()->create(['Name' => 'Acme Hospital']);
+
+        $this->getJson('/api/admin/organizations?q=memorial', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.0.name', 'Memorial Hermann')
+            ->assertJsonMissing(['name' => 'Acme Hospital']);
+    }
+
+    public function test_departments_scoped_to_organization_and_active_only(): void
+    {
+        $org = Organization::factory()->create();
+        Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'Emergency', 'Active' => 'Y']);
+        Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'Closed Wing', 'Active' => 'N']);
+        Department::factory()->create(['Name' => 'Other Org Dept', 'Active' => 'Y']);
+
+        $response = $this->getJson("/api/admin/organizations/{$org->ID}/departments", $this->headers())
+            ->assertOk();
+
+        $names = array_column($response->json('data'), 'name');
+        $this->assertContains('Emergency', $names);
+        $this->assertNotContains('Closed Wing', $names);
+        $this->assertNotContains('Other Org Dept', $names);
+    }
+
+    public function test_user_search_scoped_to_client_org_matches_login_and_name(): void
+    {
+        $dept = Department::factory()->create();
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'organization_id' => $dept->OrganizationID]);
+        User::factory()->create(['Login' => 'jane@acme.com', 'FirstName' => 'Jane', 'LastName' => 'Smith', 'DepartmentID' => $dept->ID]);
+        $otherDept = Department::factory()->create();
+        User::factory()->create(['Login' => 'jane@other.com', 'FirstName' => 'Jane', 'LastName' => 'Elsewhere', 'DepartmentID' => $otherDept->ID]);
+
+        $byLogin = $this->getJson('/api/admin/saml-clients/acme/users?q=jane@acme', $this->headers())->assertOk();
+        $this->assertSame('jane@acme.com', $byLogin->json('data.0.login'));
+        $this->assertCount(1, $byLogin->json('data'));
+
+        $byName = $this->getJson('/api/admin/saml-clients/acme/users?q=Smith', $this->headers())->assertOk();
+        $this->assertSame('jane@acme.com', $byName->json('data.0.login'));
+        $this->assertCount(1, $byName->json('data'));
+    }
+
+    public function test_user_search_unknown_slug_404s(): void
+    {
+        $this->getJson('/api/admin/saml-clients/nope/users?q=x', $this->headers())->assertNotFound();
+    }
+}

--- a/tests/Feature/AdminPortalSamlLoginTest.php
+++ b/tests/Feature/AdminPortalSamlLoginTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\SamlResponseFactory;
+use Tests\TestCase;
+
+class AdminPortalSamlLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'saml.sp.cert_path' => base_path('tests/Fixtures/saml/sp.crt'),
+            'saml.sp.key_path' => base_path('tests/Fixtures/saml/sp.key'),
+            'saml.replay_store' => 'array',
+            'saml.admin_portal_url' => 'http://localhost/admin',
+        ]);
+
+        SamlClient::factory()->adminPortal()->create([
+            'slug' => 'apex-admin',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'organization_id' => 933,
+            'jit_enabled' => false,
+        ]);
+
+        DB::table('Employees')->insert([
+            'Email' => 'sso.user@acme.test', 'FirstName' => 'Sso', 'LastName' => 'User',
+            'Password' => md5('p6^8&irrelevant'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    private function acs(array $responseOverrides = []): TestResponse
+    {
+        return $this->post('/saml/apex-admin/acs', [
+            'SAMLResponse' => SamlResponseFactory::make(
+                ['destination' => url('/saml/apex-admin/acs')] + $responseOverrides
+            ),
+        ]);
+    }
+
+    public function test_active_employee_is_redirected_to_portal_with_token(): void
+    {
+        $response = $this->acs();
+
+        $response->assertStatus(302);
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith('http://localhost/admin/ssoLogon.php?token=', $location);
+
+        parse_str(parse_url($location, PHP_URL_QUERY), $query);
+        $payload = app(AdminSsoHandoff::class)->redeem($query['token']);
+        $this->assertSame('Sso User', $payload['name']);
+    }
+
+    public function test_no_laravel_session_and_no_user_row(): void
+    {
+        $this->acs();
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('Users', ['Login' => 'sso.user@acme.test']);
+    }
+
+    public function test_unknown_email_gets_rejection_page(): void
+    {
+        $response = $this->acs(['nameId' => 'ghost@acme.test', 'attributes' => [
+            'email' => 'ghost@acme.test', 'firstName' => 'Gho', 'lastName' => 'St',
+        ]]);
+
+        $response->assertStatus(403);
+        $this->assertGuest();
+    }
+
+    public function test_inactive_employee_gets_rejection_page(): void
+    {
+        DB::table('Employees')->where('Email', 'sso.user@acme.test')->update(['Active' => 'N']);
+
+        $this->acs()->assertStatus(403);
+    }
+}

--- a/tests/Feature/AdminPortalSamlLoginTest.php
+++ b/tests/Feature/AdminPortalSamlLoginTest.php
@@ -32,7 +32,7 @@ class AdminPortalSamlLoginTest extends TestCase
             'idp_entity_id' => 'https://idp.acme.test/metadata',
             'idp_sso_url' => 'https://idp.acme.test/sso',
             'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
-            'organization_id' => 933,
+            'owner_id' => 933,
             'jit_enabled' => false,
         ]);
 

--- a/tests/Feature/AdminRoutingRulesTest.php
+++ b/tests/Feature/AdminRoutingRulesTest.php
@@ -10,21 +10,23 @@ use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminRoutingRulesTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     private function headers(): array
     {
-        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+        return $this->adminApiHeaders();
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        config(['admin.api_token' => 'test-token']);
+        $this->configureAdminApi();
     }
 
     public function test_get_returns_ordered_rules_with_catch_all_flags(): void

--- a/tests/Feature/AdminRoutingRulesTest.php
+++ b/tests/Feature/AdminRoutingRulesTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Models\System;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class AdminRoutingRulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function headers(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['admin.api_token' => 'test-token']);
+    }
+
+    public function test_get_returns_ordered_rules_with_catch_all_flags(): void
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create(['Name' => 'Mercy West']);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        SamlOrgRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'position' => 1,
+            'attribute' => 'hospital',
+            'operator' => 'equals',
+            'value' => 'Mercy West',
+            'organization_id' => $orgA->ID,
+        ]);
+        SamlOrgRule::factory()->catchAll()->create([
+            'saml_client_id' => $client->id,
+            'position' => 2,
+            'organization_id' => $orgA->ID,
+        ]);
+
+        SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'position' => 1,
+            'attribute' => 'group',
+            'operator' => 'contains',
+            'value' => 'nurse',
+            'department_name' => 'ICU Nursing',
+        ]);
+        SamlDepartmentRule::factory()->catchAll()->create([
+            'saml_client_id' => $client->id,
+            'position' => 2,
+            'department_name' => 'General',
+        ]);
+
+        $response = $this->getJson('/api/admin/saml-clients/acme/routing-rules', $this->headers())->assertOk();
+
+        $response->assertJsonPath('data.org_rules.0.attribute', 'hospital');
+        $response->assertJsonPath('data.org_rules.0.operator', 'equals');
+        $response->assertJsonPath('data.org_rules.0.value', 'Mercy West');
+        $response->assertJsonPath('data.org_rules.0.organization_id', $orgA->ID);
+        $response->assertJsonPath('data.org_rules.0.organization_name', 'Mercy West');
+        $response->assertJsonPath('data.org_rules.0.catch_all', false);
+        $response->assertJsonPath('data.org_rules.1.attribute', '*');
+        $response->assertJsonPath('data.org_rules.1.catch_all', true);
+
+        $response->assertJsonPath('data.department_rules.0.attribute', 'group');
+        $response->assertJsonPath('data.department_rules.0.operator', 'contains');
+        $response->assertJsonPath('data.department_rules.0.value', 'nurse');
+        $response->assertJsonPath('data.department_rules.0.department_name', 'ICU Nursing');
+        $response->assertJsonPath('data.department_rules.0.catch_all', false);
+        $response->assertJsonPath('data.department_rules.1.catch_all', true);
+    }
+
+    public function test_put_replaces_rules_and_returns_get_shape(): void
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create(['Name' => 'Mercy West']);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        $payload = [
+            'org_rules' => [
+                ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'Mercy West', 'organization_id' => $orgA->ID],
+            ],
+            'department_rules' => [
+                ['attribute' => 'group', 'operator' => 'contains', 'value' => 'nurse', 'department_name' => 'ICU Nursing'],
+            ],
+        ];
+
+        $response = $this->putJson('/api/admin/saml-clients/acme/routing-rules', $payload, $this->headers())
+            ->assertOk();
+
+        $response->assertJsonPath('data.org_rules.0.attribute', 'hospital');
+        $response->assertJsonPath('data.org_rules.0.operator', 'equals');
+        $response->assertJsonPath('data.org_rules.0.organization_name', 'Mercy West');
+        $response->assertJsonPath('data.department_rules.0.department_name', 'ICU Nursing');
+
+        $this->assertDatabaseCount('saml_org_rules', 1);
+        $this->assertDatabaseCount('saml_department_rules', 1);
+    }
+
+    public function test_put_validation_failure_surfaces_manager_keys(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $org->ID]);
+
+        $payload = [
+            'org_rules' => [
+                ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'x', 'organization_id' => $org->ID],
+            ],
+            'department_rules' => [],
+        ];
+
+        $response = $this->putJson('/api/admin/saml-clients/acme/routing-rules', $payload, $this->headers())
+            ->assertStatus(422);
+
+        $response->assertJsonValidationErrors(['org_rules']);
+    }
+
+    public function test_put_logs_audit_with_slug_counts_and_tuples(): void
+    {
+        Log::spy();
+
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        $payload = [
+            'org_rules' => [
+                ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'Mercy West', 'organization_id' => $orgA->ID],
+            ],
+            'department_rules' => [
+                ['attribute' => 'group', 'operator' => 'contains', 'value' => 'nurse', 'department_name' => 'ICU Nursing'],
+            ],
+        ];
+
+        $this->putJson('/api/admin/saml-clients/acme/routing-rules', $payload, $this->headers())->assertOk();
+
+        Log::shouldHaveReceived('info')->withArgs(function (string $message, array $context) {
+            return $message === 'admin api: replace routing rules'
+                && ($context['slug'] ?? null) === 'acme'
+                && ($context['org_rule_count'] ?? null) === 1
+                && ($context['department_rule_count'] ?? null) === 1
+                && isset($context['org_rules'][0]['attribute'])
+                && isset($context['department_rules'][0]['attribute']);
+        })->once();
+    }
+
+    public function test_routable_organizations_for_org_owned_client(): void
+    {
+        $org = Organization::factory()->create(['Name' => 'Solo Org']);
+        SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $org->ID]);
+        Organization::factory()->create(['Name' => 'Unrelated Org']);
+
+        $response = $this->getJson('/api/admin/saml-clients/acme/routable-organizations', $this->headers())
+            ->assertOk();
+
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $org->ID);
+        $response->assertJsonPath('data.0.name', 'Solo Org');
+    }
+
+    public function test_routable_organizations_for_system_owned_client_ordered_by_name(): void
+    {
+        $system = System::factory()->create();
+        $orgB = Organization::factory()->create(['Name' => 'Zeta Health']);
+        $orgA = Organization::factory()->create(['Name' => 'Alpha Health']);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        $response = $this->getJson('/api/admin/saml-clients/acme/routable-organizations', $this->headers())
+            ->assertOk();
+
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('data.0.name', 'Alpha Health');
+        $response->assertJsonPath('data.1.name', 'Zeta Health');
+    }
+
+    public function test_routing_rule_routes_require_a_valid_token(): void
+    {
+        $client = SamlClient::factory()->create(['slug' => 'acme']);
+
+        $getRoutes = [
+            "/api/admin/saml-clients/{$client->slug}/routing-rules",
+            "/api/admin/saml-clients/{$client->slug}/routable-organizations",
+        ];
+
+        foreach ($getRoutes as $route) {
+            $this->getJson($route)->assertUnauthorized();
+            $this->getJson($route, ['Authorization' => 'Bearer wrong-token'])->assertUnauthorized();
+        }
+
+        $putPayload = ['org_rules' => [], 'department_rules' => []];
+        $this->putJson("/api/admin/saml-clients/{$client->slug}/routing-rules", $putPayload)->assertUnauthorized();
+        $this->putJson("/api/admin/saml-clients/{$client->slug}/routing-rules", $putPayload, ['Authorization' => 'Bearer wrong-token'])->assertUnauthorized();
+    }
+}

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\SamlAttributeObservation;
 use App\Models\SamlClient;
 use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -74,5 +75,18 @@ class AdminSamlClientReadTest extends TestCase
             ->assertJsonPath('data.owner.type', 'system')
             ->assertJsonPath('data.owner.id', $system->ID)
             ->assertJsonPath('data.owner.name', 'Mercy Health System');
+    }
+
+    public function test_detail_includes_known_attributes_and_observations(): void
+    {
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'known_attributes' => ['department']]);
+        SamlAttributeObservation::factory()->create([
+            'saml_client_id' => $client->id, 'name' => 'department', 'last_seen_at' => now(),
+        ]);
+
+        $this->getJson('/api/admin/saml-clients/acme', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.known_attributes', ['department'])
+            ->assertJsonPath('data.attribute_observations.0.name', 'department');
     }
 }

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -44,7 +44,7 @@ class AdminSamlClientReadTest extends TestCase
             ->assertJsonPath('data.slug', 'acme')
             ->assertJsonPath('data.acs_url', $client->acsUrl())
             ->assertJsonStructure(['data' => ['acs_url', 'metadata_url', 'idp_entity_id',
-                'idp_sso_url', 'attribute_map', 'grants_count']]);
+                'idp_sso_url', 'attribute_map', 'organization_name', 'grants_count']]);
     }
 
     public function test_unknown_slug_404s(): void

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\SamlClient;
+use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -31,7 +32,7 @@ class AdminSamlClientReadTest extends TestCase
             ->assertOk()
             ->assertJsonPath('data.0.slug', fn ($v) => is_string($v))
             ->assertJsonStructure(['data' => [['name', 'slug', 'enabled', 'jit_enabled',
-                'organization_id', 'department_id', 'email_domains',
+                'owner' => ['type', 'id', 'name'], 'department_id', 'email_domains',
                 'certificate' => ['expires_at', 'expiring']]]]);
     }
 
@@ -44,7 +45,7 @@ class AdminSamlClientReadTest extends TestCase
             ->assertJsonPath('data.slug', 'acme')
             ->assertJsonPath('data.acs_url', $client->acsUrl())
             ->assertJsonStructure(['data' => ['acs_url', 'metadata_url', 'idp_entity_id',
-                'idp_sso_url', 'attribute_map', 'organization_name', 'grants_count']]);
+                'idp_sso_url', 'attribute_map', 'owner' => ['type', 'id', 'name'], 'grants_count']]);
     }
 
     public function test_unknown_slug_404s(): void
@@ -59,5 +60,17 @@ class AdminSamlClientReadTest extends TestCase
         $this->getJson('/api/admin/saml-clients/apex-admin', $this->headers())
             ->assertOk()
             ->assertJsonPath('data.admin_portal', true);
+    }
+
+    public function test_detail_shows_system_owner(): void
+    {
+        $system = System::factory()->create(['Name' => 'Mercy Health System']);
+        SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'sys', 'department_id' => null]);
+
+        $this->getJson('/api/admin/saml-clients/sys', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.owner.type', 'system')
+            ->assertJsonPath('data.owner.id', $system->ID)
+            ->assertJsonPath('data.owner.name', 'Mercy Health System');
     }
 }

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -51,4 +51,13 @@ class AdminSamlClientReadTest extends TestCase
     {
         $this->getJson('/api/admin/saml-clients/nope', $this->headers())->assertNotFound();
     }
+
+    public function test_detail_includes_admin_portal_flag(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->getJson('/api/admin/saml-clients/apex-admin', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.admin_portal', true);
+    }
 }

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminSamlClientReadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function headers(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['admin.api_token' => 'test-token']);
+    }
+
+    public function test_index_lists_clients_with_certificate_status(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme', 'email_domains' => ['acme.com']]);
+
+        $this->getJson('/api/admin/saml-clients', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.0.slug', fn ($v) => is_string($v))
+            ->assertJsonStructure(['data' => [['name', 'slug', 'enabled', 'jit_enabled',
+                'organization_id', 'department_id', 'email_domains',
+                'certificate' => ['expires_at', 'expiring']]]]);
+    }
+
+    public function test_show_returns_full_detail(): void
+    {
+        $client = SamlClient::factory()->create(['slug' => 'acme']);
+
+        $this->getJson('/api/admin/saml-clients/acme', $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.slug', 'acme')
+            ->assertJsonPath('data.acs_url', $client->acsUrl())
+            ->assertJsonStructure(['data' => ['acs_url', 'metadata_url', 'idp_entity_id',
+                'idp_sso_url', 'attribute_map', 'grants_count']]);
+    }
+
+    public function test_unknown_slug_404s(): void
+    {
+        $this->getJson('/api/admin/saml-clients/nope', $this->headers())->assertNotFound();
+    }
+}

--- a/tests/Feature/AdminSamlClientReadTest.php
+++ b/tests/Feature/AdminSamlClientReadTest.php
@@ -5,23 +5,25 @@ namespace Tests\Feature;
 use App\Models\SamlClient;
 use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminSamlClientReadTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     protected $seed = true;
 
     private function headers(): array
     {
-        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+        return $this->adminApiHeaders();
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        config(['admin.api_token' => 'test-token']);
+        $this->configureAdminApi();
     }
 
     public function test_index_lists_clients_with_certificate_status(): void

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -105,4 +105,13 @@ class AdminSamlClientWriteTest extends TestCase
                    ! array_key_exists('email_domains', $context);
         })->once();
     }
+
+    public function test_api_rejects_domains_on_admin_portal_client(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->patchJson('/api/admin/saml-clients/apex-admin', ['email_domains' => ['apexinnovations.com']], $this->headers())
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('email_domains');
+    }
 }

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -5,23 +5,25 @@ namespace Tests\Feature;
 use App\Models\SamlClient;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminSamlClientWriteTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     protected $seed = true;
 
     private function headers(): array
     {
-        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+        return $this->adminApiHeaders();
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        config(['admin.api_token' => 'test-token']);
+        $this->configureAdminApi();
     }
 
     public function test_create_returns_201_with_detail(): void

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -28,6 +28,7 @@ class AdminSamlClientWriteTest extends TestCase
     {
         $this->postJson('/api/admin/saml-clients', [
             'name' => 'Acme Hospital',
+            'owner_type' => 'organization',
             'owner_id' => 1,
             'email_domains' => ['acme.com'],
         ], $this->headers())

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminSamlClientWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function headers(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '1:Test Admin'];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['admin.api_token' => 'test-token']);
+    }
+
+    public function test_create_returns_201_with_detail(): void
+    {
+        $this->postJson('/api/admin/saml-clients', [
+            'name' => 'Acme Hospital',
+            'organization_id' => 1,
+            'email_domains' => ['acme.com'],
+        ], $this->headers())
+            ->assertCreated()
+            ->assertJsonPath('data.slug', 'acme-hospital')
+            ->assertJsonPath('data.enabled', false)
+            ->assertJsonPath('data.email_domains', ['acme.com']);
+    }
+
+    public function test_validation_errors_surface_as_422_bag(): void
+    {
+        SamlClient::factory()->create(['slug' => 'taken']);
+
+        $this->postJson('/api/admin/saml-clients', [
+            'name' => 'Other', 'slug' => 'taken', 'organization_id' => 1,
+        ], $this->headers())
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('slug');
+    }
+
+    public function test_update_patches_fields(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme', 'jit_enabled' => false]);
+
+        $this->patchJson('/api/admin/saml-clients/acme', ['jit_enabled' => true], $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.jit_enabled', true);
+    }
+
+    public function test_idp_metadata_upload_populates_idp_fields(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme', 'idp_entity_id' => 'pending']);
+
+        $this->postJson('/api/admin/saml-clients/acme/idp-metadata', [
+            'xml' => file_get_contents(base_path('tests/Fixtures/saml/okta-idp-metadata.xml')),
+        ], $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.idp_entity_id', fn ($v) => $v !== 'pending');
+    }
+
+    public function test_unparseable_metadata_is_a_422(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme']);
+
+        $this->postJson('/api/admin/saml-clients/acme/idp-metadata', ['xml' => 'not xml'],
+            $this->headers())->assertStatus(422)->assertJsonValidationErrors('xml');
+    }
+
+    public function test_enable_and_disable(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme', 'enabled' => false]);
+
+        $this->postJson('/api/admin/saml-clients/acme/enable', [], $this->headers())
+            ->assertOk()->assertJsonPath('data.enabled', true);
+
+        $this->postJson('/api/admin/saml-clients/acme/disable', [], $this->headers())
+            ->assertOk()->assertJsonPath('data.enabled', false);
+    }
+}

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -38,6 +38,25 @@ class AdminSamlClientWriteTest extends TestCase
             ->assertJsonPath('data.email_domains', ['acme.com']);
     }
 
+    public function test_create_with_owner_type_id_appears_in_audit(): void
+    {
+        Log::spy();
+
+        $this->postJson('/api/admin/saml-clients', [
+            'name' => 'Acme Hospital',
+            'owner_type' => 'organization',
+            'owner_id' => 1,
+            'email_domains' => ['acme.com'],
+        ], $this->headers())
+            ->assertCreated();
+
+        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+            return isset($context['fields']) &&
+                   in_array('owner_type', $context['fields']) &&
+                   in_array('owner_id', $context['fields']);
+        })->once();
+    }
+
     public function test_validation_errors_surface_as_422_bag(): void
     {
         SamlClient::factory()->create(['slug' => 'taken']);

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\SamlClient;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class AdminSamlClientWriteTest extends TestCase
@@ -84,5 +85,24 @@ class AdminSamlClientWriteTest extends TestCase
 
         $this->postJson('/api/admin/saml-clients/acme/disable', [], $this->headers())
             ->assertOk()->assertJsonPath('data.enabled', false);
+    }
+
+    public function test_audit_fields_reflect_only_submitted_editable_fields(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme', 'jit_enabled' => false]);
+
+        Log::spy();
+
+        $this->patchJson('/api/admin/saml-clients/acme', [
+            'jit_enabled' => true,
+            'bogus_field' => 'x',
+        ], $this->headers())
+            ->assertOk();
+
+        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+            return isset($context['fields']) &&
+                   $context['fields'] === ['jit_enabled'] &&
+                   ! array_key_exists('email_domains', $context);
+        })->once();
     }
 }

--- a/tests/Feature/AdminSamlClientWriteTest.php
+++ b/tests/Feature/AdminSamlClientWriteTest.php
@@ -28,7 +28,7 @@ class AdminSamlClientWriteTest extends TestCase
     {
         $this->postJson('/api/admin/saml-clients', [
             'name' => 'Acme Hospital',
-            'organization_id' => 1,
+            'owner_id' => 1,
             'email_domains' => ['acme.com'],
         ], $this->headers())
             ->assertCreated()
@@ -42,7 +42,7 @@ class AdminSamlClientWriteTest extends TestCase
         SamlClient::factory()->create(['slug' => 'taken']);
 
         $this->postJson('/api/admin/saml-clients', [
-            'name' => 'Other', 'slug' => 'taken', 'organization_id' => 1,
+            'name' => 'Other', 'slug' => 'taken', 'owner_id' => 1,
         ], $this->headers())
             ->assertStatus(422)
             ->assertJsonValidationErrors('slug');

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -123,6 +123,7 @@ class AdminSsoGrantTest extends TestCase
 
         $this->assertDatabaseHas('sso_grants', ['user_id' => $userA->ID, 'owner_type' => 'system', 'owner_id' => $system->ID]);
         $this->assertDatabaseHas('sso_grants', ['user_id' => $userB->ID, 'owner_type' => 'system', 'owner_id' => $system->ID]);
+        $this->assertDatabaseCount('sso_grants', 2);
     }
 
     public function test_grant_outside_owner_scope_is_rejected(): void

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\SamlClient;
+use App\Models\SsoGrant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminSsoGrantTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private SamlClient $client;
+
+    private Department $department;
+
+    private function headers(): array
+    {
+        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '7:Jane Admin'];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['admin.api_token' => 'test-token']);
+
+        $this->department = Department::factory()->create();
+        $this->client = SamlClient::factory()->create([
+            'slug' => 'acme',
+            'organization_id' => $this->department->OrganizationID,
+        ]);
+    }
+
+    public function test_replace_and_list_grants(): void
+    {
+        $user = User::factory()->create([
+            'Login' => 'grantee@acme.com',
+            'DepartmentID' => $this->department->ID,
+        ]);
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['grantee@acme.com']],
+            $this->headers())
+            ->assertOk()
+            ->assertJsonPath('data.0.login', 'grantee@acme.com')
+            ->assertJsonPath('data.0.granted_by', '7:Jane Admin');
+
+        $this->getJson('/api/admin/saml-clients/acme/grants', $this->headers())
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $this->assertDatabaseHas('sso_grants', [
+            'user_id' => $user->ID,
+            'organization_id' => $this->client->organization_id,
+        ]);
+    }
+
+    public function test_replace_removes_grants_not_in_the_list(): void
+    {
+        $keep = User::factory()->create(['Login' => 'keep@acme.com', 'DepartmentID' => $this->department->ID]);
+        $drop = User::factory()->create(['Login' => 'drop@acme.com', 'DepartmentID' => $this->department->ID]);
+        SsoGrant::factory()->create(['user_id' => $drop->ID, 'organization_id' => $this->client->organization_id]);
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['keep@acme.com']],
+            $this->headers())->assertOk()->assertJsonCount(1, 'data');
+
+        $this->assertDatabaseMissing('sso_grants', ['user_id' => $drop->ID]);
+    }
+
+    public function test_unknown_login_and_wrong_org_are_422(): void
+    {
+        $otherDept = Department::factory()->create();
+        User::factory()->create(['Login' => 'other@org.com', 'DepartmentID' => $otherDept->ID]);
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['ghost@acme.com']],
+            $this->headers())->assertStatus(422)->assertJsonValidationErrors('logins');
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['other@org.com']],
+            $this->headers())->assertStatus(422)->assertJsonValidationErrors('logins');
+    }
+}

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -3,10 +3,13 @@
 namespace Tests\Feature;
 
 use App\Models\Department;
+use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SsoGrant;
+use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class AdminSsoGrantTest extends TestCase
@@ -101,5 +104,34 @@ class AdminSsoGrantTest extends TestCase
 
         $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['nodept@acme.com']],
             $this->headers())->assertStatus(422)->assertJsonValidationErrors('logins');
+    }
+
+    public function test_system_owned_client_accepts_grants_across_its_orgs(): void
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+        foreach ([$orgA, $orgB] as $org) {
+            DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        }
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'sys', 'department_id' => null]);
+        $userA = User::factory()->create(['DepartmentID' => Department::factory()->create(['OrganizationID' => $orgA->ID])->ID]);
+        $userB = User::factory()->create(['DepartmentID' => Department::factory()->create(['OrganizationID' => $orgB->ID])->ID]);
+
+        $this->putJson('/api/admin/saml-clients/sys/grants', ['logins' => [$userA->Login, $userB->Login]], $this->headers())
+            ->assertOk();
+
+        $this->assertDatabaseHas('sso_grants', ['user_id' => $userA->ID, 'owner_type' => 'system', 'owner_id' => $system->ID]);
+        $this->assertDatabaseHas('sso_grants', ['user_id' => $userB->ID, 'owner_type' => 'system', 'owner_id' => $system->ID]);
+    }
+
+    public function test_grant_outside_owner_scope_is_rejected(): void
+    {
+        $system = System::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'sys', 'department_id' => null]);
+        $outsider = User::factory()->create();
+
+        $this->putJson('/api/admin/saml-clients/sys/grants', ['logins' => [$outsider->Login]], $this->headers())
+            ->assertStatus(422);
     }
 }

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -32,7 +32,7 @@ class AdminSsoGrantTest extends TestCase
         $this->department = Department::factory()->create();
         $this->client = SamlClient::factory()->create([
             'slug' => 'acme',
-            'organization_id' => $this->department->OrganizationID,
+            'owner_id' => $this->department->OrganizationID,
         ]);
     }
 
@@ -55,7 +55,7 @@ class AdminSsoGrantTest extends TestCase
 
         $this->assertDatabaseHas('sso_grants', [
             'user_id' => $user->ID,
-            'organization_id' => $this->client->organization_id,
+            'owner_id' => $this->client->owner_id,
         ]);
     }
 
@@ -63,7 +63,7 @@ class AdminSsoGrantTest extends TestCase
     {
         $keep = User::factory()->create(['Login' => 'keep@acme.com', 'DepartmentID' => $this->department->ID]);
         $drop = User::factory()->create(['Login' => 'drop@acme.com', 'DepartmentID' => $this->department->ID]);
-        SsoGrant::factory()->create(['user_id' => $drop->ID, 'organization_id' => $this->client->organization_id]);
+        SsoGrant::factory()->create(['user_id' => $drop->ID, 'owner_id' => $this->client->owner_id]);
 
         $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['keep@acme.com']],
             $this->headers())->assertOk()->assertJsonCount(1, 'data');
@@ -86,7 +86,7 @@ class AdminSsoGrantTest extends TestCase
     public function test_empty_logins_list_clears_all_grants(): void
     {
         $user = User::factory()->create(['Login' => 'grantee@acme.com', 'DepartmentID' => $this->department->ID]);
-        SsoGrant::factory()->create(['user_id' => $user->ID, 'organization_id' => $this->client->organization_id]);
+        SsoGrant::factory()->create(['user_id' => $user->ID, 'owner_id' => $this->client->owner_id]);
 
         $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => []], $this->headers())
             ->assertOk()

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -10,10 +10,12 @@ use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\InteractsWithAdminApi;
 use Tests\TestCase;
 
 class AdminSsoGrantTest extends TestCase
 {
+    use InteractsWithAdminApi;
     use RefreshDatabase;
 
     protected $seed = true;
@@ -24,13 +26,13 @@ class AdminSsoGrantTest extends TestCase
 
     private function headers(): array
     {
-        return ['Authorization' => 'Bearer test-token', 'X-Acting-Admin' => '7:Jane Admin'];
+        return $this->adminApiHeaders('7:Jane Admin');
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        config(['admin.api_token' => 'test-token']);
+        $this->configureAdminApi();
 
         $this->department = Department::factory()->create();
         $this->client = SamlClient::factory()->create([

--- a/tests/Feature/AdminSsoGrantTest.php
+++ b/tests/Feature/AdminSsoGrantTest.php
@@ -82,4 +82,24 @@ class AdminSsoGrantTest extends TestCase
         $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['other@org.com']],
             $this->headers())->assertStatus(422)->assertJsonValidationErrors('logins');
     }
+
+    public function test_empty_logins_list_clears_all_grants(): void
+    {
+        $user = User::factory()->create(['Login' => 'grantee@acme.com', 'DepartmentID' => $this->department->ID]);
+        SsoGrant::factory()->create(['user_id' => $user->ID, 'organization_id' => $this->client->organization_id]);
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => []], $this->headers())
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+
+        $this->assertDatabaseCount('sso_grants', 0);
+    }
+
+    public function test_user_with_null_department_is_rejected(): void
+    {
+        User::factory()->create(['Login' => 'nodept@acme.com', 'DepartmentID' => 0]);
+
+        $this->putJson('/api/admin/saml-clients/acme/grants', ['logins' => ['nodept@acme.com']],
+            $this->headers())->assertStatus(422)->assertJsonValidationErrors('logins');
+    }
 }

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -6,6 +6,7 @@ use App\Models\SamlClient;
 use App\Saml\AdminSsoHandoff;
 use App\Saml\SamlLoginRejected;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -72,5 +73,18 @@ class AdminSsoHandoffTest extends TestCase
     public function test_redeem_of_garbage_token_is_null(): void
     {
         $this->assertNull($this->handoff->redeem('nope'));
+    }
+
+    public function test_redemption_is_blocked_by_the_claim_even_if_payload_survives(): void
+    {
+        $url = $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertNotNull($this->handoff->redeem($query['token']));
+
+        // Simulate the get-then-forget race remnant: re-insert the payload.
+        Cache::store('array')->put('admin_sso:token:'.$query['token'], ['employee_id' => 1, 'name' => 'Ghost'], 60);
+
+        $this->assertNull($this->handoff->redeem($query['token']));
     }
 }

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Saml\AdminSsoHandoff;
+use App\Saml\SamlLoginRejected;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdminSsoHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AdminSsoHandoff $handoff;
+
+    private SamlClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['saml.replay_store' => 'array', 'saml.admin_portal_url' => 'https://www.apexinnovations.com/admin']);
+
+        $this->handoff = app(AdminSsoHandoff::class);
+        $this->client = SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        DB::table('Employees')->insert([
+            'Email' => 'jane@apexinnovations.com', 'FirstName' => 'Jane', 'LastName' => 'Doe',
+            'Password' => md5('p6^8&irrelevant'), 'Active' => 'Y',
+            'PasswordLastChanged' => now()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public function test_active_employee_gets_single_use_token(): void
+    {
+        $url = $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+
+        $this->assertStringStartsWith('https://www.apexinnovations.com/admin/ssoLogon.php?token=', $url);
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $this->assertSame(64, strlen($query['token']));
+
+        $payload = $this->handoff->redeem($query['token']);
+        $employeeId = DB::table('Employees')->where('Email', 'jane@apexinnovations.com')->value('ID');
+        $this->assertSame(['employee_id' => $employeeId, 'name' => 'Jane Doe'], $payload);
+
+        // single use
+        $this->assertNull($this->handoff->redeem($query['token']));
+    }
+
+    public function test_unknown_email_is_rejected(): void
+    {
+        $this->expectException(SamlLoginRejected::class);
+
+        try {
+            $this->handoff->initiate($this->client, 'stranger@apexinnovations.com');
+        } catch (SamlLoginRejected $e) {
+            $this->assertSame('no_employee_match', $e->logContext['reason']);
+            throw $e;
+        }
+    }
+
+    public function test_inactive_employee_is_rejected(): void
+    {
+        DB::table('Employees')->where('Email', 'jane@apexinnovations.com')->update(['Active' => 'N']);
+
+        $this->expectException(SamlLoginRejected::class);
+        $this->handoff->initiate($this->client, 'jane@apexinnovations.com');
+    }
+
+    public function test_redeem_of_garbage_token_is_null(): void
+    {
+        $this->assertNull($this->handoff->redeem('nope'));
+    }
+}

--- a/tests/Feature/AdminSsoHandoffTest.php
+++ b/tests/Feature/AdminSsoHandoffTest.php
@@ -8,6 +8,7 @@ use App\Saml\SamlLoginRejected;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class AdminSsoHandoffTest extends TestCase
@@ -86,5 +87,14 @@ class AdminSsoHandoffTest extends TestCase
         Cache::store('array')->put('admin_sso:token:'.$query['token'], ['employee_id' => 1, 'name' => 'Ghost'], 60);
 
         $this->assertNull($this->handoff->redeem($query['token']));
+    }
+
+    public function test_failed_redemption_is_logged(): void
+    {
+        Log::spy();
+
+        $this->assertNull($this->handoff->redeem('unknown-token'));
+
+        Log::shouldHaveReceived('warning')->with('Admin SSO handoff redemption failed', ['already_claimed' => false]);
     }
 }

--- a/tests/Feature/AttributeRouterTest.php
+++ b/tests/Feature/AttributeRouterTest.php
@@ -12,6 +12,7 @@ use App\Saml\AttributeRouter;
 use App\Saml\RoutingOperator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class AttributeRouterTest extends TestCase
@@ -71,6 +72,35 @@ class AttributeRouterTest extends TestCase
         $this->assertSame('General', Department::find($placement['department_id'])->Name);
     }
 
+    public function test_duplicate_department_names_resolve_to_the_lowest_id(): void
+    {
+        // The legacy Departments table enforces UNIQUE(Name, OrganizationID)
+        // for all current writes, so two active rows with the same name in
+        // one org can't be constructed through normal inserts (verified:
+        // even case- and trailing-space variants collide under this
+        // column's case-insensitive, pad-space collation). The resolver
+        // still has to behave deterministically if it ever sees legacy data
+        // that predates the constraint, so pin the query shape directly:
+        // the department lookup orders by ID descending before the
+        // name-keyed pluck, so a later (lower-ID) row always overwrites an
+        // earlier (higher-ID) one for the same name — the lowest ID wins.
+        $org = Organization::factory()->create();
+        Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'Radiology']);
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+        SamlDepartmentRule::factory()->catchAll()->create(['saml_client_id' => $client->id, 'department_name' => 'Radiology']);
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        app(AttributeRouter::class)->route($client, []);
+
+        $departmentQuery = collect($queries)->first(fn ($sql) => str_contains($sql, 'from `Departments`'));
+        $this->assertNotNull($departmentQuery, 'Expected a Departments query to run.');
+        $this->assertStringContainsString('order by `ID` desc', $departmentQuery);
+    }
+
     public function test_inactive_departments_never_resolve(): void
     {
         $org = Organization::factory()->create();
@@ -88,6 +118,31 @@ class AttributeRouterTest extends TestCase
         SamlOrgRule::factory()->catchAll()->create(['saml_client_id' => $client->id, 'organization_id' => $orgA->ID]);
 
         $this->assertSame($orgA->ID, app(AttributeRouter::class)->route($client, [])['organization_id']);
+    }
+
+    public function test_stale_out_of_scope_org_rule_is_skipped_with_warning(): void
+    {
+        [$system, $orgA, $orgB] = $this->seedSystemWithTwoOrgs();
+        $outsideOrg = Organization::factory()->create(); // never added to the system's pivot rows
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['department_id' => null]);
+
+        // Earlier, matching rule targets an org no longer in scope (stale
+        // re-parent); a later rule targets an in-scope org and should win.
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 1,
+            'attribute' => '*', 'operator' => RoutingOperator::Wildcard, 'value' => '*', 'organization_id' => $outsideOrg->ID]);
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 2,
+            'attribute' => '*', 'operator' => RoutingOperator::Wildcard, 'value' => '*', 'organization_id' => $orgA->ID]);
+
+        Log::spy();
+
+        $placement = app(AttributeRouter::class)->route($client, []);
+
+        $this->assertSame($orgA->ID, $placement['organization_id']);
+        Log::shouldHaveReceived('warning')->withArgs(function (string $message, array $context) use ($client, $outsideOrg) {
+            return $message === 'Routing rule targets organization outside client scope'
+                && ($context['client'] ?? null) === $client->slug
+                && ($context['organization_id'] ?? null) === $outsideOrg->ID;
+        })->once();
     }
 
     /** @return array{0: System, 1: Organization, 2: Organization} */

--- a/tests/Feature/AttributeRouterTest.php
+++ b/tests/Feature/AttributeRouterTest.php
@@ -7,17 +7,18 @@ use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SamlDepartmentRule;
 use App\Models\SamlOrgRule;
-use App\Models\System;
 use App\Saml\AttributeRouter;
 use App\Saml\RoutingOperator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Tests\Support\SeedsSystemHierarchy;
 use Tests\TestCase;
 
 class AttributeRouterTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsSystemHierarchy;
 
     public function test_org_owned_ignores_org_rules_and_routes_department_by_name(): void
     {
@@ -143,18 +144,5 @@ class AttributeRouterTest extends TestCase
                 && ($context['client'] ?? null) === $client->slug
                 && ($context['organization_id'] ?? null) === $outsideOrg->ID;
         })->once();
-    }
-
-    /** @return array{0: System, 1: Organization, 2: Organization} */
-    private function seedSystemWithTwoOrgs(): array
-    {
-        $system = System::factory()->create();
-        $orgA = Organization::factory()->create();
-        $orgB = Organization::factory()->create();
-
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
-
-        return [$system, $orgA, $orgB];
     }
 }

--- a/tests/Feature/AttributeRouterTest.php
+++ b/tests/Feature/AttributeRouterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Models\System;
+use App\Saml\AttributeRouter;
+use App\Saml\RoutingOperator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AttributeRouterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_org_owned_ignores_org_rules_and_routes_department_by_name(): void
+    {
+        $org = Organization::factory()->create();
+        $dept = Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'ICU Nursing']);
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'organization_id' => 999999]); // ignored
+        SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id, 'attribute' => 'department',
+            'operator' => RoutingOperator::Contains, 'value' => 'icu', 'department_name' => 'icu nursing',
+        ]);
+
+        $placement = app(AttributeRouter::class)->route($client, ['department' => ['Medical ICU']]);
+
+        $this->assertSame(['organization_id' => $org->ID, 'department_id' => $dept->ID], $placement);
+    }
+
+    public function test_system_owned_stage_one_first_match_wins(): void
+    {
+        [$system, $orgA, $orgB] = $this->seedSystemWithTwoOrgs(); // helper: System + 2 orgs + pivot rows
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['department_id' => null]);
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 1,
+            'attribute' => 'hospital', 'operator' => RoutingOperator::Equals, 'value' => 'mercy west', 'organization_id' => $orgA->ID]);
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 2,
+            'attribute' => 'hospital', 'operator' => RoutingOperator::Wildcard, 'value' => '*', 'organization_id' => $orgB->ID]);
+
+        $this->assertSame($orgA->ID, app(AttributeRouter::class)->route($client, ['hospital' => ['Mercy West']])['organization_id']);
+        $this->assertSame($orgB->ID, app(AttributeRouter::class)->route($client, ['hospital' => ['Other']])['organization_id']);
+    }
+
+    public function test_system_owned_no_match_uses_fallback_then_null(): void
+    {
+        [$system] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['department_id' => null]);
+
+        $this->assertNull(app(AttributeRouter::class)->route($client, []));
+        $this->assertSame(42, app(AttributeRouter::class)->route($client, [], 42)['organization_id']);
+    }
+
+    public function test_department_fall_through_when_name_missing_in_resolved_org(): void
+    {
+        $org = Organization::factory()->create();
+        Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'General']);
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id, 'position' => 1,
+            'attribute' => 'group', 'operator' => RoutingOperator::Contains, 'value' => 'nurse', 'department_name' => 'Cath Lab']);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id, 'position' => 2,
+            'attribute' => 'group', 'operator' => RoutingOperator::Contains, 'value' => 'nurse', 'department_name' => 'General']);
+
+        $placement = app(AttributeRouter::class)->route($client, ['group' => ['ICU-Nurses']]);
+
+        $this->assertSame('General', Department::find($placement['department_id'])->Name);
+    }
+
+    public function test_inactive_departments_never_resolve(): void
+    {
+        $org = Organization::factory()->create();
+        Department::factory()->create(['OrganizationID' => $org->ID, 'Name' => 'Old Wing', 'Active' => 'N']);
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+        SamlDepartmentRule::factory()->catchAll()->create(['saml_client_id' => $client->id, 'department_name' => 'Old Wing']);
+
+        $this->assertNull(app(AttributeRouter::class)->route($client, [])['department_id']);
+    }
+
+    public function test_catch_all_org_rule_matches_empty_assertion(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['department_id' => null]);
+        SamlOrgRule::factory()->catchAll()->create(['saml_client_id' => $client->id, 'organization_id' => $orgA->ID]);
+
+        $this->assertSame($orgA->ID, app(AttributeRouter::class)->route($client, [])['organization_id']);
+    }
+
+    /** @return array{0: System, 1: Organization, 2: Organization} */
+    private function seedSystemWithTwoOrgs(): array
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+
+        return [$system, $orgA, $orgB];
+    }
+}

--- a/tests/Feature/AttributeRoutingLoginTest.php
+++ b/tests/Feature/AttributeRoutingLoginTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Models\System;
+use App\Models\User;
+use App\Saml\RoutingOperator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\SamlResponseFactory;
+use Tests\TestCase;
+
+class AttributeRoutingLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private SamlClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'saml.sp.cert_path' => base_path('tests/Fixtures/saml/sp.crt'),
+            'saml.sp.key_path' => base_path('tests/Fixtures/saml/sp.key'),
+            'saml.replay_store' => 'array',
+        ]);
+
+        $this->client = SamlClient::factory()->create([
+            'slug' => 'acme',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'owner_id' => 933,
+            'department_id' => null,
+            'jit_enabled' => true,
+        ]);
+    }
+
+    private function acs(array $responseOverrides = []): TestResponse
+    {
+        return $this->post('/saml/acme/acs', [
+            'SAMLResponse' => SamlResponseFactory::make($responseOverrides),
+        ]);
+    }
+
+    private function departmentRule(SamlClient $client, string $departmentName, string $value, string $attribute = 'department'): SamlDepartmentRule
+    {
+        return SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'attribute' => $attribute,
+            'operator' => RoutingOperator::Contains,
+            'value' => $value,
+            'department_name' => $departmentName,
+        ]);
+    }
+
+    public function test_jit_user_is_routed_to_named_department(): void
+    {
+        $dept = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->departmentRule($this->client, 'ICU Nursing', 'icu');
+
+        // Routed JIT users still have CredentialID = 0, so they land on the
+        // finish flow (with their department pre-resolved) — same as clients
+        // with a static default department today.
+        $this->acs(['attributes' => ['email' => 'new@acme.test', 'firstName' => 'N', 'lastName' => 'U', 'department' => 'Medical ICU'], 'nameId' => 'new@acme.test'])
+            ->assertRedirect('/finishAccountCreation');
+
+        $this->assertDatabaseHas('Users', ['Login' => 'new@acme.test', 'DepartmentID' => $dept->ID]);
+    }
+
+    public function test_jit_user_with_no_matching_rule_gets_client_default_department(): void
+    {
+        Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->departmentRule($this->client, 'ICU Nursing', 'icu');
+
+        $this->acs(['attributes' => ['email' => 'new@acme.test', 'firstName' => 'N', 'lastName' => 'U', 'department' => 'Radiology'], 'nameId' => 'new@acme.test'])
+            ->assertRedirect('/finishAccountCreation');
+
+        // Org-owned client, rule set present but non-matching: department-less
+        // placement (org still resolves from ownership) -> DepartmentID 0.
+        $this->assertDatabaseHas('Users', ['Login' => 'new@acme.test', 'DepartmentID' => 0]);
+    }
+
+    public function test_existing_user_is_moved_to_routed_department(): void
+    {
+        $deptA = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Old Wing']);
+        $deptB = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->departmentRule($this->client, 'ICU Nursing', 'icu');
+
+        $user = User::factory()->create([
+            'Login' => 'mover@acme.test',
+            'DepartmentID' => $deptA->ID,
+            'CredentialID' => 1,
+        ]);
+
+        Log::spy();
+
+        $response = $this->acs(['nameId' => 'mover@acme.test', 'attributes' => [
+            'email' => 'mover@acme.test', 'firstName' => 'Mover', 'lastName' => 'User', 'department' => 'Medical ICU',
+        ]]);
+
+        $response->assertRedirect('https://www.apexinnovations.com/MyCurriculum.php');
+        $this->assertDatabaseHas('Users', ['Login' => 'mover@acme.test', 'DepartmentID' => $deptB->ID]);
+
+        Log::shouldHaveReceived('info')->withArgs(function (string $message, array $context) use ($user, $deptA, $deptB) {
+            return $message === 'SAML routed user to department'
+                && ($context['client'] ?? null) === 'acme'
+                && ($context['user_id'] ?? null) === $user->ID
+                && ($context['from'] ?? null) === $deptA->ID
+                && ($context['to'] ?? null) === $deptB->ID;
+        })->once();
+    }
+
+    public function test_existing_user_untouched_on_no_rule_match(): void
+    {
+        $deptA = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Old Wing']);
+        Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->departmentRule($this->client, 'ICU Nursing', 'icu');
+
+        User::factory()->create([
+            'Login' => 'stays@acme.test',
+            'DepartmentID' => $deptA->ID,
+            'CredentialID' => 1,
+        ]);
+
+        Log::spy();
+
+        $this->acs(['nameId' => 'stays@acme.test', 'attributes' => [
+            'email' => 'stays@acme.test', 'firstName' => 'Stays', 'lastName' => 'User', 'department' => 'Radiology',
+        ]]);
+
+        $this->assertDatabaseHas('Users', ['Login' => 'stays@acme.test', 'DepartmentID' => $deptA->ID]);
+        Log::shouldNotHaveReceived('info', ['SAML routed user to department', \Mockery::any()]);
+    }
+
+    public function test_existing_user_never_demoted_when_rule_matches_but_department_missing(): void
+    {
+        $deptA = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Old Wing']);
+        // Rule matches the attribute but names a department that does not
+        // exist anywhere -> placement resolves department_id null, must not touch the user.
+        $this->departmentRule($this->client, 'Nonexistent Department', 'icu');
+
+        User::factory()->create([
+            'Login' => 'safe@acme.test',
+            'DepartmentID' => $deptA->ID,
+            'CredentialID' => 1,
+        ]);
+
+        Log::spy();
+
+        $this->acs(['nameId' => 'safe@acme.test', 'attributes' => [
+            'email' => 'safe@acme.test', 'firstName' => 'Safe', 'lastName' => 'User', 'department' => 'Medical ICU',
+        ]]);
+
+        $this->assertDatabaseHas('Users', ['Login' => 'safe@acme.test', 'DepartmentID' => $deptA->ID]);
+        Log::shouldNotHaveReceived('info', ['SAML routed user to department', \Mockery::any()]);
+    }
+
+    public function test_system_owned_org_rule_catch_all_rescues_jit(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert([
+            'SystemID' => $system->ID,
+            'OrganizationID' => $org->ID,
+        ]);
+
+        $sysClient = SamlClient::factory()->forSystem($system->ID)->create([
+            'slug' => 'sys',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'jit_enabled' => true,
+            'department_id' => null,
+        ]);
+
+        SamlOrgRule::factory()->catchAll()->create([
+            'saml_client_id' => $sysClient->id,
+            'organization_id' => $org->ID,
+        ]);
+
+        $response = $this->post('/saml/sys/acs', [
+            'SAMLResponse' => SamlResponseFactory::make([
+                'destination' => url('/saml/sys/acs'),
+                'attributes' => ['email' => 'rescued@acme.test', 'firstName' => 'R', 'lastName' => 'U'],
+                'nameId' => 'rescued@acme.test',
+            ]),
+        ]);
+
+        $response->assertRedirect('/finishAccountCreation');
+        $response->assertSessionHas('Organization', $org->ID);
+        $this->assertDatabaseHas('Users', ['Login' => 'rescued@acme.test', 'DepartmentID' => 0]);
+    }
+
+    public function test_system_owned_no_rules_still_rejects_unrouted(): void
+    {
+        $system = System::factory()->create();
+
+        $sysClient = SamlClient::factory()->forSystem($system->ID)->create([
+            'slug' => 'sys',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'jit_enabled' => true,
+            'department_id' => null,
+        ]);
+
+        $response = $this->post('/saml/sys/acs', [
+            'SAMLResponse' => SamlResponseFactory::make([
+                'destination' => url('/saml/sys/acs'),
+            ]),
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertGuest();
+        $this->assertDatabaseMissing('Users', ['Login' => 'sso.user@acme.test']);
+    }
+
+    public function test_org_owned_zero_rules_is_byte_for_byte_unchanged(): void
+    {
+        // No routing rules at all on an org-owned client: placement resolves
+        // organization_id from ownership, department_id null (no rules to
+        // match) -> identical to the pre-routing default-department fallback.
+        $response = $this->acs();
+
+        $this->assertAuthenticated();
+        $response->assertRedirect('/finishAccountCreation'); // DepartmentID 0
+        $this->assertDatabaseHas('Users', ['Login' => 'sso.user@acme.test', 'DepartmentID' => 0]);
+        $response->assertSessionHas('Organization', 933);
+    }
+
+    public function test_session_organization_reflects_routed_placement_for_org_owned_client(): void
+    {
+        $dept = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->departmentRule($this->client, 'ICU Nursing', 'icu');
+
+        $response = $this->acs(['attributes' => [
+            'email' => 'routed@acme.test', 'firstName' => 'R', 'lastName' => 'U', 'department' => 'Medical ICU',
+        ], 'nameId' => 'routed@acme.test']);
+
+        $response->assertSessionHas('Organization', $this->client->owner_id);
+        $this->assertDatabaseHas('Users', ['Login' => 'routed@acme.test', 'DepartmentID' => $dept->ID]);
+    }
+
+    public function test_org_owned_default_department_survives_when_no_rule_matches(): void
+    {
+        $dept = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Default Dept']);
+        $this->client->update(['department_id' => $dept->ID]);
+        // A department rule that will NOT match this login:
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $this->client->id,
+            'attribute' => 'department', 'operator' => RoutingOperator::Equals, 'value' => 'nope', 'department_name' => 'Default Dept']);
+
+        $this->acs(['attributes' => ['email' => 'defaulted@acme.test', 'firstName' => 'D', 'lastName' => 'F', 'department' => 'Radiology'], 'nameId' => 'defaulted@acme.test']);
+
+        $this->assertDatabaseHas('Users', ['Login' => 'defaulted@acme.test', 'DepartmentID' => $dept->ID]);
+    }
+
+    public function test_resolving_department_rule_beats_the_static_default(): void
+    {
+        $default = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Default Dept']);
+        $routed = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'ICU Nursing']);
+        $this->client->update(['department_id' => $default->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $this->client->id,
+            'attribute' => 'department', 'operator' => RoutingOperator::Contains, 'value' => 'icu', 'department_name' => 'ICU Nursing']);
+
+        $this->acs(['attributes' => ['email' => 'routed@acme.test', 'firstName' => 'R', 'lastName' => 'T', 'department' => 'Medical ICU'], 'nameId' => 'routed@acme.test']);
+
+        $this->assertDatabaseHas('Users', ['Login' => 'routed@acme.test', 'DepartmentID' => $routed->ID]);
+    }
+}

--- a/tests/Feature/AttributeRoutingLoginTest.php
+++ b/tests/Feature/AttributeRoutingLoginTest.php
@@ -265,6 +265,48 @@ class AttributeRoutingLoginTest extends TestCase
         $this->assertDatabaseHas('Users', ['Login' => 'defaulted@acme.test', 'DepartmentID' => $dept->ID]);
     }
 
+    public function test_system_owned_existing_user_unmoved_keeps_own_org_in_session_despite_org_rule_match(): void
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+
+        $sysClient = SamlClient::factory()->forSystem($system->ID)->create([
+            'slug' => 'sys',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'jit_enabled' => true,
+            'department_id' => null,
+        ]);
+
+        // Org rule routes everyone to org B, but no department rule resolves
+        // for this login — the provisioner leaves the existing user's
+        // department untouched (never demoted), so the session org must
+        // reflect their real (org A) department, not the routed org B.
+        SamlOrgRule::factory()->catchAll()->create(['saml_client_id' => $sysClient->id, 'organization_id' => $orgB->ID]);
+
+        $deptA = Department::factory()->create(['OrganizationID' => $orgA->ID, 'Name' => 'Old Wing']);
+        User::factory()->create([
+            'Login' => 'stays@acme.test',
+            'DepartmentID' => $deptA->ID,
+            'CredentialID' => 1,
+        ]);
+
+        $response = $this->post('/saml/sys/acs', [
+            'SAMLResponse' => SamlResponseFactory::make([
+                'destination' => url('/saml/sys/acs'),
+                'attributes' => ['email' => 'stays@acme.test', 'firstName' => 'S', 'lastName' => 'U'],
+                'nameId' => 'stays@acme.test',
+            ]),
+        ]);
+
+        $this->assertDatabaseHas('Users', ['Login' => 'stays@acme.test', 'DepartmentID' => $deptA->ID]);
+        $response->assertSessionHas('Organization', $orgA->ID);
+    }
+
     public function test_resolving_department_rule_beats_the_static_default(): void
     {
         $default = Department::factory()->create(['OrganizationID' => $this->client->owner_id, 'Name' => 'Default Dept']);

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -120,7 +120,7 @@ class HierarchyFactoryTest extends TestCase
 
         $this->assertSame(1, System::where('Name', 'Memorial Health System')->count());
         $this->assertSame($orgA->system->ID, $orgB->system->ID);
-        $this->assertDatabaseCount('SystemOrganizations', 2);
+        $this->assertSame(2, SystemOrganization::where('SystemID', $orgA->system->ID)->count());
     }
 
     public function test_for_system_with_model_attaches_to_it(): void

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -136,21 +136,19 @@ class HierarchyFactoryTest extends TestCase
 
     public function test_for_system_without_argument_creates_a_fresh_system(): void
     {
-        $org = Organization::factory()->forSystem()->create();
+        $orgA = Organization::factory()->forSystem()->create();
+        $orgB = Organization::factory()->forSystem()->create();
 
-        $this->assertNotNull($org->system);
+        $this->assertNotNull($orgA->system);
+        $this->assertNotNull($orgB->system);
+        $this->assertNotSame($orgA->system->ID, $orgB->system->ID);
     }
 
     public function test_reattaching_an_org_replaces_its_system(): void
     {
         $first = System::factory()->create();
         $second = System::factory()->create();
-        $org = Organization::factory()->forSystem($first)->create();
-
-        SystemOrganization::updateOrCreate(
-            ['OrganizationID' => $org->ID],
-            ['SystemID' => $second->ID],
-        );
+        $org = Organization::factory()->forSystem($first)->forSystem($second)->create();
 
         $this->assertSame(1, SystemOrganization::where('OrganizationID', $org->ID)->count());
         $this->assertSame($second->ID, $org->fresh()->system->ID);

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -171,4 +171,40 @@ class HierarchyFactoryTest extends TestCase
             $org->departments->pluck('Name')->all(),
         );
     }
+
+    public function test_with_organizations_builds_the_full_tree(): void
+    {
+        $system = System::factory()->withOrganizations(3, departmentsEach: 2)->create();
+
+        $this->assertCount(3, $system->organizations);
+        foreach ($system->organizations as $org) {
+            $this->assertSame($system->ID, $org->system->ID);
+            $this->assertCount(2, $org->departments);
+        }
+    }
+
+    public function test_with_organizations_applies_explicit_department_names_per_org(): void
+    {
+        $system = System::factory()
+            ->withOrganizations(2, departmentsEach: ['Emergency', 'ICU'])
+            ->create();
+
+        foreach ($system->organizations as $org) {
+            $this->assertEqualsCanonicalizing(
+                ['Emergency', 'ICU'],
+                $org->departments->pluck('Name')->all(),
+            );
+        }
+    }
+
+    public function test_many_org_seed_does_not_exhaust_the_name_pool(): void
+    {
+        $system = System::factory()->withOrganizations(10, departmentsEach: 3)->create();
+
+        $this->assertCount(10, $system->organizations);
+        $this->assertSame(30, Department::whereIn(
+            'OrganizationID',
+            $system->organizations->pluck('ID'),
+        )->count());
+    }
 }

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -152,4 +152,23 @@ class HierarchyFactoryTest extends TestCase
         $this->assertSame(1, SystemOrganization::where('OrganizationID', $org->ID)->count());
         $this->assertSame($second->ID, $org->fresh()->system->ID);
     }
+
+    public function test_with_departments_count_creates_distinct_names(): void
+    {
+        $org = Organization::factory()->withDepartments(4)->create();
+
+        $names = $org->departments->pluck('Name');
+        $this->assertCount(4, $names);
+        $this->assertCount(4, $names->unique());
+    }
+
+    public function test_with_departments_accepts_explicit_names(): void
+    {
+        $org = Organization::factory()->withDepartments(['Emergency', 'ICU'])->create();
+
+        $this->assertEqualsCanonicalizing(
+            ['Emergency', 'ICU'],
+            $org->departments->pluck('Name')->all(),
+        );
+    }
 }

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -112,4 +112,44 @@ class HierarchyFactoryTest extends TestCase
         $this->assertTrue($user->adminOrganizations->contains('ID', $org->ID));
         $this->assertTrue($user->adminSystems->contains('ID', $system->ID));
     }
+
+    public function test_for_system_with_string_shares_one_system_across_orgs(): void
+    {
+        $orgA = Organization::factory()->forSystem('Memorial Health System')->create();
+        $orgB = Organization::factory()->forSystem('Memorial Health System')->create();
+
+        $this->assertSame(1, System::where('Name', 'Memorial Health System')->count());
+        $this->assertSame($orgA->system->ID, $orgB->system->ID);
+        $this->assertDatabaseCount('SystemOrganizations', 2);
+    }
+
+    public function test_for_system_with_model_attaches_to_it(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->forSystem($system)->create();
+
+        $this->assertSame($system->ID, $org->system->ID);
+    }
+
+    public function test_for_system_without_argument_creates_a_fresh_system(): void
+    {
+        $org = Organization::factory()->forSystem()->create();
+
+        $this->assertNotNull($org->system);
+    }
+
+    public function test_reattaching_an_org_replaces_its_system(): void
+    {
+        $first = System::factory()->create();
+        $second = System::factory()->create();
+        $org = Organization::factory()->forSystem($first)->create();
+
+        SystemOrganization::updateOrCreate(
+            ['OrganizationID' => $org->ID],
+            ['SystemID' => $second->ID],
+        );
+
+        $this->assertSame(1, SystemOrganization::where('OrganizationID', $org->ID)->count());
+        $this->assertSame($second->ID, $org->fresh()->system->ID);
+    }
 }

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -28,7 +28,7 @@ class HierarchyFactoryTest extends TestCase
             ->create();
 
         $this->assertCount(2, $system->organizations);
-        $this->assertDatabaseCount('SystemOrganizations', 2);
+        $this->assertDatabaseHas('SystemOrganizations', ['SystemID' => $system->ID]);
     }
 
     public function test_organization_factory_satisfies_constraints_without_seeding(): void

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -120,6 +120,9 @@ class HierarchyFactoryTest extends TestCase
 
         $this->assertSame(1, System::where('Name', 'Memorial Health System')->count());
         $this->assertSame($orgA->system->ID, $orgB->system->ID);
+        // Scoped to this system, not table-wide: $seed = true tests run migrate:fresh --seed
+        // once per process, before any per-test transaction starts, so ReferenceDataSeeder's
+        // 2 SystemOrganizations rows are committed and persist across the rest of the suite.
         $this->assertSame(2, SystemOrganization::where('SystemID', $orgA->system->ID)->count());
     }
 

--- a/tests/Feature/HierarchyFactoryTest.php
+++ b/tests/Feature/HierarchyFactoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\System;
+use App\Models\SystemOrganization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -29,6 +30,23 @@ class HierarchyFactoryTest extends TestCase
 
         $this->assertCount(2, $system->organizations);
         $this->assertDatabaseHas('SystemOrganizations', ['SystemID' => $system->ID]);
+    }
+
+    public function test_organization_system_relation_returns_owning_system(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create();
+        SystemOrganization::create(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+
+        $this->assertNotNull($org->system);
+        $this->assertSame($system->ID, $org->system->ID);
+    }
+
+    public function test_organization_without_system_returns_null(): void
+    {
+        $org = Organization::factory()->create();
+
+        $this->assertNull($org->system);
     }
 
     public function test_organization_factory_satisfies_constraints_without_seeding(): void

--- a/tests/Feature/KnownAttributeCaptureLoginTest.php
+++ b/tests/Feature/KnownAttributeCaptureLoginTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\SamlResponseFactory;
+use Tests\TestCase;
+
+class KnownAttributeCaptureLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private SamlClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'saml.sp.cert_path' => base_path('tests/Fixtures/saml/sp.crt'),
+            'saml.sp.key_path' => base_path('tests/Fixtures/saml/sp.key'),
+            'saml.replay_store' => 'array',
+        ]);
+
+        $this->client = SamlClient::factory()->create([
+            'slug' => 'acme',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'owner_id' => 933,
+            'department_id' => null,
+            'jit_enabled' => true,
+        ]);
+    }
+
+    private function acs(array $responseOverrides = []): TestResponse
+    {
+        return $this->post('/saml/acme/acs', [
+            'SAMLResponse' => SamlResponseFactory::make($responseOverrides),
+        ]);
+    }
+
+    public function test_login_captures_asserted_attribute_names(): void
+    {
+        $this->acs(['attributes' => [
+            'email' => 'sso.user@acme.test', 'firstName' => 'Sso', 'lastName' => 'User',
+            'department' => 'ICU', 'eduPersonAffiliation' => 'staff',
+        ]]);
+
+        $known = $this->client->fresh()->known_attributes;
+        $this->assertContains('department', $known);
+        $this->assertContains('eduPersonAffiliation', $known);
+        $this->assertNotContains('email', $known); // identity attribute excluded
+        $this->assertDatabaseHas('saml_attribute_observations', ['saml_client_id' => $this->client->id, 'name' => 'department']);
+        $this->assertDatabaseMissing('saml_attribute_observations', ['name' => 'ICU']); // never a value
+    }
+}

--- a/tests/Feature/KnownAttributeCollectorTest.php
+++ b/tests/Feature/KnownAttributeCollectorTest.php
@@ -41,7 +41,7 @@ class KnownAttributeCollectorTest extends TestCase
             'known_attributes' => [],
         ]);
 
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         $this->assertEqualsCanonicalizing(['department', 'eduPersonAffiliation'], $client->fresh()->known_attributes);
     }
@@ -50,7 +50,7 @@ class KnownAttributeCollectorTest extends TestCase
     {
         $client = SamlClient::factory()->create(['attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName']]);
 
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         // No stored string anywhere equals an asserted VALUE.
         foreach (['jane@acme.test', 'Jane', 'Doe', 'Cardiology', 'staff', 'member'] as $value) {
@@ -63,8 +63,8 @@ class KnownAttributeCollectorTest extends TestCase
     {
         $client = SamlClient::factory()->create(['attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName']]);
 
-        $this->collector->capture($client, $this->assertion());
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         $obs = SamlAttributeObservation::where('saml_client_id', $client->id)->where('name', 'department')->first();
         $this->assertSame(2, $obs->observation_count);
@@ -80,7 +80,7 @@ class KnownAttributeCollectorTest extends TestCase
         $before = $client->updated_at;
         $this->travel(1)->minutes();
 
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         $this->assertEquals($before, $client->fresh()->updated_at); // column untouched
     }
@@ -89,7 +89,7 @@ class KnownAttributeCollectorTest extends TestCase
     {
         $client = SamlClient::factory()->adminPortal()->create();
 
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         $this->assertSame([], $client->fresh()->known_attributes);
         $this->assertDatabaseCount('saml_attribute_observations', 0);
@@ -102,21 +102,20 @@ class KnownAttributeCollectorTest extends TestCase
             'attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName'],
         ]);
 
-        // Force a genuine throw from inside capture by making the observation
-        // save fail. Bind a model event that throws when save() is called on
-        // SamlAttributeObservation.
-        SamlAttributeObservation::saving(function () {
-            throw new \RuntimeException('Simulated DB failure during observation save');
-        });
+        // Force a genuine throw from inside capture. The implementation uses
+        // an atomic upsert() (no model events fire), so drop the schema
+        // underneath it to make the query itself fail — this exercises the
+        // real code path the collector executes, not a model event hook.
+        \Illuminate\Support\Facades\Schema::drop('saml_attribute_observations');
 
         // Must NOT throw out of capture (a capture failure can never break a login).
-        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, array_keys($this->assertion()));
 
         // Verify the warning was logged with the correct message and context.
         Log::shouldHaveReceived('warning')
             ->once()
             ->withArgs(fn ($message, $context = []) => $message === 'known-attribute capture failed'
                 && ($context['client'] ?? null) === $client->slug
-                && str_contains($context['error'] ?? '', 'Simulated DB failure'));
+                && str_contains($context['error'] ?? '', 'saml_attribute_observations'));
     }
 }

--- a/tests/Feature/KnownAttributeCollectorTest.php
+++ b/tests/Feature/KnownAttributeCollectorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlAttributeObservation;
+use App\Models\SamlClient;
+use App\Saml\KnownAttributeCollector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class KnownAttributeCollectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private KnownAttributeCollector $collector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->collector = app(KnownAttributeCollector::class);
+    }
+
+    private function assertion(): array
+    {
+        // php-saml getAttributes() shape: name => [values]. Values are PHI in
+        // real life; the collector must ignore them entirely.
+        return [
+            'email' => ['jane@acme.test'],
+            'firstName' => ['Jane'],
+            'lastName' => ['Doe'],
+            'department' => ['Cardiology'],
+            'eduPersonAffiliation' => ['staff', 'member'],
+        ];
+    }
+
+    public function test_captures_non_identity_names_only(): void
+    {
+        $client = SamlClient::factory()->create([
+            'attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName'],
+            'known_attributes' => [],
+        ]);
+
+        $this->collector->capture($client, $this->assertion());
+
+        $this->assertEqualsCanonicalizing(['department', 'eduPersonAffiliation'], $client->fresh()->known_attributes);
+    }
+
+    public function test_never_persists_a_value(): void
+    {
+        $client = SamlClient::factory()->create(['attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName']]);
+
+        $this->collector->capture($client, $this->assertion());
+
+        // No stored string anywhere equals an asserted VALUE.
+        foreach (['jane@acme.test', 'Jane', 'Doe', 'Cardiology', 'staff', 'member'] as $value) {
+            $this->assertDatabaseMissing('saml_attribute_observations', ['name' => $value]);
+        }
+        $this->assertNotContains('Cardiology', $client->fresh()->known_attributes);
+    }
+
+    public function test_upserts_observations_with_counts(): void
+    {
+        $client = SamlClient::factory()->create(['attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName']]);
+
+        $this->collector->capture($client, $this->assertion());
+        $this->collector->capture($client, $this->assertion());
+
+        $obs = SamlAttributeObservation::where('saml_client_id', $client->id)->where('name', 'department')->first();
+        $this->assertSame(2, $obs->observation_count);
+        $this->assertNotNull($obs->first_seen_at);
+    }
+
+    public function test_no_saml_clients_write_when_nothing_new(): void
+    {
+        $client = SamlClient::factory()->create([
+            'attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName'],
+            'known_attributes' => ['department', 'eduPersonAffiliation'],
+        ]);
+        $before = $client->updated_at;
+        $this->travel(1)->minutes();
+
+        $this->collector->capture($client, $this->assertion());
+
+        $this->assertEquals($before, $client->fresh()->updated_at); // column untouched
+    }
+
+    public function test_admin_portal_clients_are_skipped(): void
+    {
+        $client = SamlClient::factory()->adminPortal()->create();
+
+        $this->collector->capture($client, $this->assertion());
+
+        $this->assertSame([], $client->fresh()->known_attributes);
+        $this->assertDatabaseCount('saml_attribute_observations', 0);
+    }
+
+    public function test_capture_swallows_and_logs_a_real_failure(): void
+    {
+        Log::spy();
+        $client = SamlClient::factory()->create([
+            'attribute_map' => ['email' => 'email', 'first_name' => 'firstName', 'last_name' => 'lastName'],
+        ]);
+
+        // Force a genuine throw from inside capture by making the observation
+        // save fail. Bind a model event that throws when save() is called on
+        // SamlAttributeObservation.
+        SamlAttributeObservation::saving(function () {
+            throw new \RuntimeException('Simulated DB failure during observation save');
+        });
+
+        // Must NOT throw out of capture (a capture failure can never break a login).
+        $this->collector->capture($client, $this->assertion());
+
+        // Verify the warning was logged with the correct message and context.
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn ($message, $context = []) => $message === 'known-attribute capture failed'
+                && ($context['client'] ?? null) === $client->slug
+                && str_contains($context['error'] ?? '', 'Simulated DB failure'));
+    }
+}

--- a/tests/Feature/KnownAttributeCollectorTest.php
+++ b/tests/Feature/KnownAttributeCollectorTest.php
@@ -7,6 +7,7 @@ use App\Models\SamlClient;
 use App\Saml\KnownAttributeCollector;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class KnownAttributeCollectorTest extends TestCase
@@ -106,7 +107,7 @@ class KnownAttributeCollectorTest extends TestCase
         // an atomic upsert() (no model events fire), so drop the schema
         // underneath it to make the query itself fail — this exercises the
         // real code path the collector executes, not a model event hook.
-        \Illuminate\Support\Facades\Schema::drop('saml_attribute_observations');
+        Schema::drop('saml_attribute_observations');
 
         // Must NOT throw out of capture (a capture failure can never break a login).
         $this->collector->capture($client, array_keys($this->assertion()));

--- a/tests/Feature/LocalEmployeeSeederTest.php
+++ b/tests/Feature/LocalEmployeeSeederTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\LocalEmployeeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class LocalEmployeeSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_seeds_an_active_portal_admin_with_legacy_hash(): void
+    {
+        $this->seed(LocalEmployeeSeeder::class);
+        $this->seed(LocalEmployeeSeeder::class); // idempotent
+
+        $rows = DB::table('Employees')->where('Email', 'dev.admin@apexinnovations.com')->get();
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Y', $rows[0]->Active);
+        $this->assertSame(md5('p6^8&password'), $rows[0]->Password);
+        $this->assertTrue(strtotime($rows[0]->PasswordLastChanged) > strtotime('-1 day'));
+    }
+}

--- a/tests/Feature/LocalHierarchySeederTest.php
+++ b/tests/Feature/LocalHierarchySeederTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\System;
+use Database\Seeders\LocalHierarchySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocalHierarchySeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_seeds_a_system_tree_and_a_standalone_org_idempotently(): void
+    {
+        $this->seed(LocalHierarchySeeder::class);
+        $this->seed(LocalHierarchySeeder::class); // idempotent
+
+        $system = System::where('Name', 'Memorial Health System')->firstOrFail();
+        $this->assertSame(1, System::where('Name', 'Memorial Health System')->count());
+        $this->assertCount(3, $system->organizations);
+        foreach ($system->organizations as $org) {
+            $this->assertCount(4, $org->departments);
+        }
+
+        $standalone = Organization::where('Name', 'Standalone Community Hospital')->firstOrFail();
+        $this->assertNull($standalone->system);
+        $this->assertSame(3, Department::where('OrganizationID', $standalone->ID)->count());
+    }
+}

--- a/tests/Feature/ReferenceDataSeederTest.php
+++ b/tests/Feature/ReferenceDataSeederTest.php
@@ -51,4 +51,11 @@ class ReferenceDataSeederTest extends TestCase
         $this->assertDatabaseHas('saml_clients', ['slug' => 'local-admin-idp', 'admin_portal' => 1, 'enabled' => 0]);
         $this->assertDatabaseHas('Employees', ['Email' => 'user1@example.com', 'Active' => 'Y']);
     }
+
+    public function test_seeder_creates_local_system_with_orgs_one_and_two(): void
+    {
+        $this->assertDatabaseHas('Systems', ['ID' => 1, 'Name' => 'Local Health System']);
+        $this->assertDatabaseHas('SystemOrganizations', ['SystemID' => 1, 'OrganizationID' => 1]);
+        $this->assertDatabaseHas('SystemOrganizations', ['SystemID' => 1, 'OrganizationID' => 2]);
+    }
 }

--- a/tests/Feature/ReferenceDataSeederTest.php
+++ b/tests/Feature/ReferenceDataSeederTest.php
@@ -45,4 +45,10 @@ class ReferenceDataSeederTest extends TestCase
         // Login, so the assertion survives dev-domain renames.)
         $this->assertDatabaseHas('Users', ['FirstName' => 'Dev', 'LastName' => 'User', 'DepartmentID' => 1]);
     }
+
+    public function test_seeder_creates_admin_portal_mock_client_and_employee(): void
+    {
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'local-admin-idp', 'admin_portal' => 1, 'enabled' => 0]);
+        $this->assertDatabaseHas('Employees', ['Email' => 'user1@example.com', 'Active' => 'Y']);
+    }
 }

--- a/tests/Feature/RoutingRuleManagerTest.php
+++ b/tests/Feature/RoutingRuleManagerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Models\System;
+use App\Saml\SamlClientManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class RoutingRuleManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_happy_replace_persists_both_lists_in_order_and_removes_old_rules(): void
+    {
+        [$system, $orgA, $orgB] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'organization_id' => $orgA->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+
+        $orgRules = [
+            ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'mercy west', 'organization_id' => $orgA->ID],
+            ['attribute' => '*', 'operator' => 'wildcard', 'value' => '*', 'organization_id' => $orgB->ID],
+        ];
+        $departmentRules = [
+            ['attribute' => 'group', 'operator' => 'contains', 'value' => 'nurse', 'department_name' => 'ICU'],
+            ['attribute' => '*', 'operator' => 'wildcard', 'value' => '*', 'department_name' => 'General'],
+        ];
+
+        $result = app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, $departmentRules);
+
+        $this->assertInstanceOf(SamlClient::class, $result);
+        $this->assertDatabaseCount('saml_org_rules', 2);
+        $this->assertDatabaseCount('saml_department_rules', 2);
+
+        $storedOrgRules = SamlOrgRule::where('saml_client_id', $client->id)->orderBy('position')->get();
+        $this->assertSame(1, $storedOrgRules[0]->position);
+        $this->assertSame('hospital', $storedOrgRules[0]->attribute);
+        $this->assertSame(2, $storedOrgRules[1]->position);
+        $this->assertSame('*', $storedOrgRules[1]->attribute);
+
+        $storedDeptRules = SamlDepartmentRule::where('saml_client_id', $client->id)->orderBy('position')->get();
+        $this->assertSame(1, $storedDeptRules[0]->position);
+        $this->assertSame('ICU', $storedDeptRules[0]->department_name);
+        $this->assertSame(2, $storedDeptRules[1]->position);
+        $this->assertSame('General', $storedDeptRules[1]->department_name);
+    }
+
+    public function test_org_rules_on_org_owned_client_rejected(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+
+        $orgRules = [
+            ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'x', 'organization_id' => $org->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('org_rules', $e->errors());
+            $this->assertSame('Organization rules require a system-owned client.', $e->errors()['org_rules'][0]);
+        }
+    }
+
+    public function test_out_of_scope_organization_rejected(): void
+    {
+        [$system] = $this->seedSystemWithTwoOrgs();
+        $outsideOrg = Organization::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $orgRules = [
+            ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'x', 'organization_id' => $outsideOrg->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('org_rules.0.organization_id', $e->errors());
+            $this->assertSame(
+                "Organization is outside this client's scope.",
+                $e->errors()['org_rules.0.organization_id'][0]
+            );
+        }
+    }
+
+    public function test_unknown_operator_string_rejected(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $orgRules = [
+            ['attribute' => 'hospital', 'operator' => 'regex', 'value' => 'x', 'organization_id' => $orgA->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('org_rules.0.operator', $e->errors());
+        }
+    }
+
+    public function test_wildcard_attribute_with_non_triple_rejected(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $orgRules = [
+            ['attribute' => '*', 'operator' => 'equals', 'value' => '*', 'organization_id' => $orgA->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('org_rules.0.attribute', $e->errors());
+        }
+    }
+
+    public function test_rule_after_catch_all_rejected(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $orgRules = [
+            ['attribute' => '*', 'operator' => 'wildcard', 'value' => '*', 'organization_id' => $orgA->ID],
+            ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'x', 'organization_id' => $orgA->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $orgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('org_rules.1', $e->errors());
+            $this->assertSame('Rules after a catch-all are unreachable.', $e->errors()['org_rules.1'][0]);
+        }
+    }
+
+    public function test_department_rule_missing_name_rejected(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+
+        $departmentRules = [
+            ['attribute' => 'group', 'operator' => 'contains', 'value' => 'nurse', 'department_name' => ''],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, [], $departmentRules);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('department_rules.0.department_name', $e->errors());
+        }
+    }
+
+    public function test_empty_lists_replace_clears_everything(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'organization_id' => $orgA->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+
+        app(SamlClientManager::class)->replaceRoutingRules($client, [], []);
+
+        $this->assertDatabaseCount('saml_org_rules', 0);
+        $this->assertDatabaseCount('saml_department_rules', 0);
+    }
+
+    public function test_failed_validation_leaves_prior_rules_intact(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $outsideOrg = Organization::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'organization_id' => $orgA->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+
+        $this->assertDatabaseCount('saml_org_rules', 1);
+        $this->assertDatabaseCount('saml_department_rules', 1);
+
+        $badOrgRules = [
+            ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'x', 'organization_id' => $outsideOrg->ID],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, $badOrgRules, []);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            // expected
+        }
+
+        $this->assertDatabaseCount('saml_org_rules', 1);
+        $this->assertDatabaseCount('saml_department_rules', 1);
+    }
+
+    /** @return array{0: System, 1: Organization, 2: Organization} */
+    private function seedSystemWithTwoOrgs(): array
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+
+        return [$system, $orgA, $orgB];
+    }
+}

--- a/tests/Feature/RoutingRuleManagerTest.php
+++ b/tests/Feature/RoutingRuleManagerTest.php
@@ -145,6 +145,25 @@ class RoutingRuleManagerTest extends TestCase
         }
     }
 
+    public function test_department_rule_after_catch_all_rejected(): void
+    {
+        [$system, $orgA] = $this->seedSystemWithTwoOrgs();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $departmentRules = [
+            ['attribute' => '*', 'operator' => 'wildcard', 'value' => '*', 'department_name' => 'General'],
+            ['attribute' => 'group', 'operator' => 'contains', 'value' => 'nurse', 'department_name' => 'ICU'],
+        ];
+
+        try {
+            app(SamlClientManager::class)->replaceRoutingRules($client, [], $departmentRules);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('department_rules.1', $e->errors());
+            $this->assertSame('Rules after a catch-all are unreachable.', $e->errors()['department_rules.1'][0]);
+        }
+    }
+
     public function test_department_rule_missing_name_rejected(): void
     {
         $org = Organization::factory()->create();

--- a/tests/Feature/RoutingRuleManagerTest.php
+++ b/tests/Feature/RoutingRuleManagerTest.php
@@ -6,16 +6,16 @@ use App\Models\Organization;
 use App\Models\SamlClient;
 use App\Models\SamlDepartmentRule;
 use App\Models\SamlOrgRule;
-use App\Models\System;
 use App\Saml\SamlClientManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Tests\Support\SeedsSystemHierarchy;
 use Tests\TestCase;
 
 class RoutingRuleManagerTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsSystemHierarchy;
 
     public function test_happy_replace_persists_both_lists_in_order_and_removes_old_rules(): void
     {
@@ -218,18 +218,5 @@ class RoutingRuleManagerTest extends TestCase
 
         $this->assertDatabaseCount('saml_org_rules', 1);
         $this->assertDatabaseCount('saml_department_rules', 1);
-    }
-
-    /** @return array{0: System, 1: Organization, 2: Organization} */
-    private function seedSystemWithTwoOrgs(): array
-    {
-        $system = System::factory()->create();
-        $orgA = Organization::factory()->create();
-        $orgB = Organization::factory()->create();
-
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
-
-        return [$system, $orgA, $orgB];
     }
 }

--- a/tests/Feature/SamlAttributeObservationTest.php
+++ b/tests/Feature/SamlAttributeObservationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlAttributeObservation;
+use App\Models\SamlClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SamlAttributeObservationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_known_attributes_defaults_to_empty_array(): void
+    {
+        $this->assertSame([], SamlClient::factory()->create()->known_attributes);
+    }
+
+    public function test_known_attributes_round_trips_as_array(): void
+    {
+        $client = SamlClient::factory()->create(['known_attributes' => ['department', 'groups']]);
+
+        $this->assertSame(['department', 'groups'], $client->fresh()->known_attributes);
+    }
+
+    public function test_null_known_attributes_column_reads_as_empty_array(): void
+    {
+        $client = SamlClient::factory()->create();
+        // Force a real NULL in the column (the factory always sets []).
+        DB::table('saml_clients')->where('id', $client->id)->update(['known_attributes' => null]);
+
+        $this->assertSame([], $client->fresh()->known_attributes);
+    }
+
+    public function test_observations_belong_to_a_client_and_cast(): void
+    {
+        $client = SamlClient::factory()->create();
+        SamlAttributeObservation::factory()->create([
+            'saml_client_id' => $client->id, 'name' => 'eduPersonAffiliation', 'observation_count' => 3,
+        ]);
+
+        $obs = $client->attributeObservations()->first();
+        $this->assertSame('eduPersonAffiliation', $obs->name);
+        $this->assertSame(3, $obs->observation_count);
+        $this->assertNotNull($obs->last_seen_at);
+    }
+}

--- a/tests/Feature/SamlClientCommandTest.php
+++ b/tests/Feature/SamlClientCommandTest.php
@@ -114,4 +114,34 @@ class SamlClientCommandTest extends TestCase
             ->expectsOutputToContain('acme.com')
             ->assertSuccessful();
     }
+
+    public function test_create_with_admin_portal_flag(): void
+    {
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933, '--admin-portal' => true,
+        ])->assertSuccessful();
+
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 1]);
+    }
+
+    public function test_admin_portal_client_cannot_claim_domains(): void
+    {
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933,
+            '--admin-portal' => true, '--domains' => 'apexinnovations.com',
+        ])->assertFailed();
+
+        $this->assertDatabaseMissing('saml_clients', ['slug' => 'apex-admin']);
+    }
+
+    public function test_update_can_toggle_admin_portal_off(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['slug' => 'apex-admin']);
+
+        $this->artisan('saml:client', [
+            'action' => 'update', 'slug' => 'apex-admin', '--no-admin-portal' => true,
+        ])->assertSuccessful();
+
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 0]);
+    }
 }

--- a/tests/Feature/SamlClientCommandTest.php
+++ b/tests/Feature/SamlClientCommandTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Feature;
 
+use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
 use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class SamlClientCommandTest extends TestCase
@@ -182,5 +186,155 @@ class SamlClientCommandTest extends TestCase
         ])->assertFailed();
 
         $this->assertDatabaseMissing('saml_clients', ['slug' => 'sys-client']);
+    }
+
+    public function test_describe_shows_routing_rule_counts(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'organization_id' => $org->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id, 'position' => 2]);
+
+        $this->artisan('saml:client', ['action' => 'describe', 'slug' => 'acme'])
+            ->expectsOutputToContain('Org rules: 1')
+            ->expectsOutputToContain('Department rules: 2')
+            ->assertSuccessful();
+    }
+
+    public function test_routing_action_renders_numbered_sentences_with_catch_all(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create(['Name' => 'Mercy West']);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        SamlOrgRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'position' => 1,
+            'attribute' => 'hospital',
+            'operator' => 'equals',
+            'value' => 'Mercy West',
+            'organization_id' => $org->ID,
+        ]);
+        SamlOrgRule::factory()->catchAll()->create([
+            'saml_client_id' => $client->id,
+            'position' => 2,
+            'organization_id' => $org->ID,
+        ]);
+        SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'position' => 1,
+            'attribute' => 'group',
+            'operator' => 'contains',
+            'value' => 'nurse',
+            'department_name' => 'ICU Nursing',
+        ]);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme'])
+            ->expectsOutputToContain("org 1. hospital equals \"Mercy West\" → Mercy West ({$org->ID})")
+            ->expectsOutputToContain('org 2. everyone →')
+            ->expectsOutputToContain('dept 1. group contains "nurse" → "ICU Nursing"')
+            ->assertSuccessful();
+    }
+
+    public function test_routing_action_set_inline_json_replaces_rules(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        $json = json_encode([
+            'org_rules' => [
+                ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'Mercy West', 'organization_id' => $org->ID],
+            ],
+            'department_rules' => [],
+        ]);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme', '--set' => $json])
+            ->assertSuccessful();
+
+        $this->assertDatabaseCount('saml_org_rules', 1);
+        $this->assertDatabaseHas('saml_org_rules', ['saml_client_id' => $client->id, 'attribute' => 'hospital']);
+    }
+
+    public function test_routing_action_set_file_replaces_rules(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        $json = json_encode([
+            'org_rules' => [
+                ['attribute' => 'hospital', 'operator' => 'equals', 'value' => 'Mercy West', 'organization_id' => $org->ID],
+            ],
+            'department_rules' => [],
+        ]);
+
+        $path = tempnam(sys_get_temp_dir(), 'routing').'.json';
+        file_put_contents($path, $json);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme', '--set-file' => $path])
+            ->assertSuccessful();
+
+        unlink($path);
+
+        $this->assertDatabaseCount('saml_org_rules', 1);
+    }
+
+    public function test_routing_action_clear_empties_both_lists(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $org->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme', '--clear' => true])
+            ->assertSuccessful();
+
+        $this->assertDatabaseCount('saml_org_rules', 0);
+        $this->assertDatabaseCount('saml_department_rules', 0);
+    }
+
+    public function test_routing_action_malformed_json_fails_cleanly(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme']);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme', '--set' => '{not valid json'])
+            ->assertFailed();
+    }
+
+    public function test_routing_action_unreadable_set_file_fails_cleanly(): void
+    {
+        SamlClient::factory()->create(['slug' => 'acme']);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme', '--set-file' => '/no/such/file.json'])
+            ->assertFailed();
+    }
+
+    public function test_no_department_clears_default_department(): void
+    {
+        $dept = Department::factory()->create();
+        $client = SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $dept->OrganizationID, 'department_id' => $dept->ID]);
+
+        $this->artisan('saml:client', [
+            'action' => 'update', 'slug' => 'acme', '--no-department' => true,
+        ])->assertSuccessful();
+
+        $this->assertNull($client->fresh()->department_id);
+    }
+
+    public function test_no_department_and_department_together_fails(): void
+    {
+        $dept = Department::factory()->create();
+        SamlClient::factory()->create(['slug' => 'acme', 'owner_id' => $dept->OrganizationID]);
+
+        $this->artisan('saml:client', [
+            'action' => 'update', 'slug' => 'acme', '--no-department' => true, '--department' => $dept->ID,
+        ])->assertFailed();
     }
 }

--- a/tests/Feature/SamlClientCommandTest.php
+++ b/tests/Feature/SamlClientCommandTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -12,7 +14,9 @@ class SamlClientCommandTest extends TestCase
 
     public function test_create_prints_urls(): void
     {
-        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Acme Health', '--org' => 1])
+        $org = Organization::factory()->create();
+
+        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Acme Health', '--org' => $org->ID])
             ->expectsOutputToContain('/saml/acme-health/acs')
             ->expectsOutputToContain('/saml/acme-health/metadata')
             ->assertSuccessful();
@@ -76,8 +80,10 @@ class SamlClientCommandTest extends TestCase
 
     public function test_create_accepts_domains_option(): void
     {
+        $org = Organization::factory()->create();
+
         $this->artisan('saml:client', [
-            'action' => 'create', '--name' => 'Acme', '--org' => '1',
+            'action' => 'create', '--name' => 'Acme', '--org' => (string) $org->ID,
             '--domains' => 'Acme.com, portal.acme.com',
         ])->assertSuccessful();
 
@@ -117,8 +123,10 @@ class SamlClientCommandTest extends TestCase
 
     public function test_create_with_admin_portal_flag(): void
     {
+        $org = Organization::factory()->create();
+
         $this->artisan('saml:client', [
-            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933, '--admin-portal' => true,
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => $org->ID, '--admin-portal' => true,
         ])->assertSuccessful();
 
         $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 1]);
@@ -126,8 +134,10 @@ class SamlClientCommandTest extends TestCase
 
     public function test_admin_portal_client_cannot_claim_domains(): void
     {
+        $org = Organization::factory()->create();
+
         $this->artisan('saml:client', [
-            'action' => 'create', '--name' => 'Apex Admin', '--org' => 933,
+            'action' => 'create', '--name' => 'Apex Admin', '--org' => $org->ID,
             '--admin-portal' => true, '--domains' => 'apexinnovations.com',
         ])->assertFailed();
 
@@ -143,5 +153,34 @@ class SamlClientCommandTest extends TestCase
         ])->assertSuccessful();
 
         $this->assertDatabaseHas('saml_clients', ['slug' => 'apex-admin', 'admin_portal' => 0]);
+    }
+
+    public function test_create_with_system_owner(): void
+    {
+        $system = System::factory()->create();
+
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Sys Client', '--system' => $system->ID,
+        ])->assertSuccessful();
+
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'sys-client', 'owner_type' => 'system', 'owner_id' => $system->ID]);
+    }
+
+    public function test_create_requires_exactly_one_owner(): void
+    {
+        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Nope'])->assertFailed();
+        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Nope', '--org' => 1, '--system' => 1])->assertFailed();
+        $this->assertDatabaseMissing('saml_clients', ['slug' => 'nope']);
+    }
+
+    public function test_system_owned_client_rejects_default_department(): void
+    {
+        $system = System::factory()->create();
+
+        $this->artisan('saml:client', [
+            'action' => 'create', '--name' => 'Sys Client', '--system' => $system->ID, '--department' => 1,
+        ])->assertFailed();
+
+        $this->assertDatabaseMissing('saml_clients', ['slug' => 'sys-client']);
     }
 }

--- a/tests/Feature/SamlClientCommandTest.php
+++ b/tests/Feature/SamlClientCommandTest.php
@@ -241,6 +241,27 @@ class SamlClientCommandTest extends TestCase
             ->assertSuccessful();
     }
 
+    public function test_routing_action_renders_negated_operator_sentence(): void
+    {
+        $system = System::factory()->create();
+        $org = Organization::factory()->create(['Name' => 'Mercy West']);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        $client = SamlClient::factory()->forSystem($system->ID)->create(['slug' => 'acme']);
+
+        SamlOrgRule::factory()->create([
+            'saml_client_id' => $client->id,
+            'position' => 1,
+            'attribute' => 'hospital',
+            'operator' => 'not_equals',
+            'value' => 'Mercy West',
+            'organization_id' => $org->ID,
+        ]);
+
+        $this->artisan('saml:client', ['action' => 'routing', 'slug' => 'acme'])
+            ->expectsOutputToContain("org 1. hospital not equals \"Mercy West\" → Mercy West ({$org->ID})")
+            ->assertSuccessful();
+    }
+
     public function test_routing_action_set_inline_json_replaces_rules(): void
     {
         $system = System::factory()->create();

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Feature;
 
+use App\Models\Department;
+use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\System;
 use App\Saml\SamlClientManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
@@ -19,9 +22,12 @@ class SamlClientManagerTest extends TestCase
 
     public function test_create_with_minimal_input_slugs_the_name(): void
     {
+        $org = Organization::factory()->create();
+
         $client = $this->manager()->create([
             'name' => 'Health System One',
-            'owner_id' => 1,
+            'owner_type' => 'organization',
+            'owner_id' => $org->ID,
         ]);
 
         $this->assertSame('health-system-one', $client->slug);
@@ -91,8 +97,10 @@ class SamlClientManagerTest extends TestCase
 
     public function test_domains_are_normalized_on_create(): void
     {
+        $org = Organization::factory()->create();
+
         $client = $this->manager()->create([
-            'name' => 'Acme', 'owner_id' => 1,
+            'name' => 'Acme', 'owner_type' => 'organization', 'owner_id' => $org->ID,
             'email_domains' => [' @MDAnderson.ORG ', 'mdanderson.org'],
         ]);
 
@@ -130,5 +138,36 @@ class SamlClientManagerTest extends TestCase
         ]);
 
         $this->assertSame(['mdanderson.org', 'mdacc.org'], $updated->email_domains);
+    }
+
+    public function test_create_rejects_unknown_owner(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->create(['name' => 'X', 'owner_type' => 'organization', 'owner_id' => 999999]);
+    }
+
+    public function test_default_department_must_belong_to_owning_org(): void
+    {
+        $org = Organization::factory()->create();
+        $otherOrgDept = Department::factory()->create(); // factory mints its own org
+
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->create([
+            'name' => 'X', 'owner_type' => 'organization', 'owner_id' => $org->ID,
+            'department_id' => $otherOrgDept->ID,
+        ]);
+    }
+
+    public function test_reparent_to_system_with_default_department_is_rejected(): void
+    {
+        $dept = Department::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $dept->OrganizationID, 'department_id' => $dept->ID]);
+        $system = System::factory()->create();
+
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->update($client, ['owner_type' => 'system', 'owner_id' => $system->ID]);
     }
 }

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -170,4 +170,22 @@ class SamlClientManagerTest extends TestCase
 
         app(SamlClientManager::class)->update($client, ['owner_type' => 'system', 'owner_id' => $system->ID]);
     }
+
+    public function test_update_rejects_owner_type_without_owner_id(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->update($client, ['owner_type' => 'system']);
+    }
+
+    public function test_update_rejects_owner_id_without_owner_type(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->update($client, ['owner_id' => 42]);
+    }
 }

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -21,7 +21,7 @@ class SamlClientManagerTest extends TestCase
     {
         $client = $this->manager()->create([
             'name' => 'Health System One',
-            'organization_id' => 1,
+            'owner_id' => 1,
         ]);
 
         $this->assertSame('health-system-one', $client->slug);
@@ -44,7 +44,7 @@ class SamlClientManagerTest extends TestCase
 
         $this->expectException(ValidationException::class);
 
-        $this->manager()->create(['name' => 'Acme', 'slug' => 'acme', 'organization_id' => 1]);
+        $this->manager()->create(['name' => 'Acme', 'slug' => 'acme', 'owner_id' => 1]);
     }
 
     public function test_update_from_idp_metadata_fills_idp_fields(): void
@@ -92,7 +92,7 @@ class SamlClientManagerTest extends TestCase
     public function test_domains_are_normalized_on_create(): void
     {
         $client = $this->manager()->create([
-            'name' => 'Acme', 'organization_id' => 1,
+            'name' => 'Acme', 'owner_id' => 1,
             'email_domains' => [' @MDAnderson.ORG ', 'mdanderson.org'],
         ]);
 
@@ -104,7 +104,7 @@ class SamlClientManagerTest extends TestCase
         $this->expectException(ValidationException::class);
 
         $this->manager()->create([
-            'name' => 'Acme', 'organization_id' => 1,
+            'name' => 'Acme', 'owner_id' => 1,
             'email_domains' => ['not a domain'],
         ]);
     }
@@ -116,7 +116,7 @@ class SamlClientManagerTest extends TestCase
         $this->expectException(ValidationException::class);
 
         $this->manager()->create([
-            'name' => 'Acme', 'organization_id' => 1,
+            'name' => 'Acme', 'owner_id' => 1,
             'email_domains' => ['mdanderson.org'],
         ]);
     }

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -143,6 +143,16 @@ class SamlClientManagerTest extends TestCase
         $this->assertSame(['mdanderson.org', 'mdacc.org'], $updated->email_domains);
     }
 
+    public function test_update_with_explicit_null_department_id_clears_it(): void
+    {
+        $dept = Department::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $dept->OrganizationID, 'department_id' => $dept->ID]);
+
+        $updated = $this->manager()->update($client, ['department_id' => null]);
+
+        $this->assertNull($updated->department_id);
+    }
+
     public function test_create_rejects_unknown_owner(): void
     {
         $this->expectException(ValidationException::class);

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -5,9 +5,12 @@ namespace Tests\Feature;
 use App\Models\Department;
 use App\Models\Organization;
 use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
 use App\Models\System;
 use App\Saml\SamlClientManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
@@ -187,5 +190,62 @@ class SamlClientManagerTest extends TestCase
         $this->expectException(ValidationException::class);
 
         app(SamlClientManager::class)->update($client, ['owner_id' => 42]);
+    }
+
+    public function test_reparent_with_org_rules_present_is_rejected(): void
+    {
+        $system = System::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id]);
+        $otherSystem = System::factory()->create();
+
+        try {
+            app(SamlClientManager::class)->update($client, ['owner_type' => 'system', 'owner_id' => $otherSystem->ID]);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('owner_id', $e->errors());
+            $this->assertSame('Clear routing rules before re-parenting this client.', $e->errors()['owner_id'][0]);
+        }
+    }
+
+    public function test_reparent_with_department_rules_present_is_rejected(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+        $otherOrg = Organization::factory()->create();
+
+        try {
+            app(SamlClientManager::class)->update($client, ['owner_type' => 'organization', 'owner_id' => $otherOrg->ID]);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('owner_id', $e->errors());
+            $this->assertSame('Clear routing rules before re-parenting this client.', $e->errors()['owner_id'][0]);
+        }
+    }
+
+    public function test_reparent_after_clearing_rules_succeeds(): void
+    {
+        $system = System::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id]);
+        $otherSystem = System::factory()->create();
+
+        DB::table('saml_org_rules')->where('saml_client_id', $client->id)->delete();
+
+        $updated = app(SamlClientManager::class)->update($client, ['owner_type' => 'system', 'owner_id' => $otherSystem->ID]);
+
+        $this->assertSame($otherSystem->ID, $updated->owner_id);
+    }
+
+    public function test_non_owner_update_with_rules_present_is_unaffected(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID, 'name' => 'Old Name']);
+        SamlDepartmentRule::factory()->create(['saml_client_id' => $client->id]);
+
+        $updated = app(SamlClientManager::class)->update($client, ['name' => 'New Name']);
+
+        $this->assertSame('New Name', $updated->name);
     }
 }

--- a/tests/Feature/SamlClientManagerTest.php
+++ b/tests/Feature/SamlClientManagerTest.php
@@ -258,4 +258,21 @@ class SamlClientManagerTest extends TestCase
 
         $this->assertSame('New Name', $updated->name);
     }
+
+    public function test_known_attributes_are_trimmed_and_deduped(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        app(SamlClientManager::class)->update($client, ['known_attributes' => [' department ', 'department', 'groups']]);
+
+        $this->assertSame(['department', 'groups'], $client->fresh()->known_attributes);
+    }
+
+    public function test_known_attributes_reject_non_string_entries(): void
+    {
+        $client = SamlClient::factory()->create();
+        $this->expectException(ValidationException::class);
+
+        app(SamlClientManager::class)->update($client, ['known_attributes' => ['ok', 123]]);
+    }
 }

--- a/tests/Feature/SamlClientModelTest.php
+++ b/tests/Feature/SamlClientModelTest.php
@@ -57,4 +57,25 @@ class SamlClientModelTest extends TestCase
 
         $this->assertNull(SamlClient::forEmailDomain('gmail.com'));
     }
+
+    public function test_admin_portal_defaults_to_false(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        $this->assertFalse($client->admin_portal);
+    }
+
+    public function test_admin_portal_state_sets_flag(): void
+    {
+        $client = SamlClient::factory()->adminPortal()->create();
+
+        $this->assertTrue($client->refresh()->admin_portal);
+    }
+
+    public function test_email_domain_lookup_never_matches_admin_portal_clients(): void
+    {
+        SamlClient::factory()->adminPortal()->create(['email_domains' => ['apexinnovations.com']]);
+
+        $this->assertNull(SamlClient::forEmailDomain('apexinnovations.com'));
+    }
 }

--- a/tests/Feature/SamlClientOwnershipTest.php
+++ b/tests/Feature/SamlClientOwnershipTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\System;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SamlClientOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // First-alphabetical RefreshDatabase caution does not apply (SamlClient…
+    // sorts after AdminApiSsoHandoffTest, which owns the seed pass).
+
+    public function test_factory_default_is_org_owned(): void
+    {
+        $client = SamlClient::factory()->create();
+
+        $this->assertTrue($client->ownedByOrganization());
+        $this->assertSame('organization', $client->owner_type);
+        $this->assertSame([$client->owner_id], $client->scopedOrganizationIds());
+    }
+
+    public function test_org_owner_name_resolves(): void
+    {
+        $org = Organization::factory()->create();
+        $client = SamlClient::factory()->create(['owner_id' => $org->ID]);
+
+        $this->assertSame($org->Name, $client->ownerName());
+    }
+
+    public function test_system_owned_scope_is_the_systems_organizations(): void
+    {
+        $system = System::factory()->create();
+        $orgs = Organization::factory()->count(2)->create();
+        foreach ($orgs as $org) {
+            DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $org->ID]);
+        }
+
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $this->assertFalse($client->ownedByOrganization());
+        $this->assertSame($system->Name, $client->ownerName());
+        $this->assertEqualsCanonicalizing($orgs->pluck('ID')->all(), $client->scopedOrganizationIds());
+    }
+
+    public function test_system_owned_with_no_orgs_has_empty_scope(): void
+    {
+        $system = System::factory()->create();
+        $client = SamlClient::factory()->forSystem($system->ID)->create();
+
+        $this->assertSame([], $client->scopedOrganizationIds());
+    }
+}

--- a/tests/Feature/SamlClientWizardTest.php
+++ b/tests/Feature/SamlClientWizardTest.php
@@ -27,6 +27,7 @@ class SamlClientWizardTest extends TestCase
         $this->artisan('saml:client', ['action' => 'create', '--wizard' => true])
             ->expectsQuestion('Client display name', 'Wizard Acme Health')
             ->expectsQuestion('URL slug', 'wizard-acme-health')
+            ->expectsChoice('Owned by', 'organization', ['organization' => 'Organization', 'system' => 'System (spans its organizations)'])
             ->expectsSearch('Organization', '4242', 'Wizard Acme', ['4242' => 'Wizard Acme Health'])
             ->expectsSearch('Default department', '5000', '', [
                 'none' => 'None — users choose at finish-account',
@@ -56,6 +57,7 @@ class SamlClientWizardTest extends TestCase
         $this->artisan('saml:client', ['action' => 'create', '--wizard' => true])
             ->expectsQuestion('Client display name', 'Wizard Acme Health')
             ->expectsQuestion('URL slug', 'wizard-acme-health')
+            ->expectsChoice('Owned by', 'organization', ['organization' => 'Organization', 'system' => 'System (spans its organizations)'])
             ->expectsSearch('Organization', '4242', 'Wizard Acme', ['4242' => 'Wizard Acme Health'])
             ->expectsSearch('Default department', 'none', '', [
                 'none' => 'None — users choose at finish-account',
@@ -76,6 +78,7 @@ class SamlClientWizardTest extends TestCase
         $this->artisan('saml:client', ['action' => 'create', '--wizard' => true])
             ->expectsQuestion('Client display name', 'Entra Corp')
             ->expectsQuestion('URL slug', 'entra-corp')
+            ->expectsChoice('Owned by', 'organization', ['organization' => 'Organization', 'system' => 'System (spans its organizations)'])
             ->expectsSearch('Organization', '4242', 'Wizard Acme', ['4242' => 'Wizard Acme Health'])
             ->expectsSearch('Default department', 'none', '', [
                 'none' => 'None — users choose at finish-account',
@@ -100,10 +103,12 @@ class SamlClientWizardTest extends TestCase
 
     public function test_flag_based_create_still_works(): void
     {
-        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Plain Co', '--org' => 7])
+        $org = Organization::factory()->create();
+
+        $this->artisan('saml:client', ['action' => 'create', '--name' => 'Plain Co', '--org' => $org->ID])
             ->expectsOutputToContain('/saml/plain-co/acs')
             ->assertSuccessful();
 
-        $this->assertDatabaseHas('saml_clients', ['slug' => 'plain-co', 'owner_id' => 7]);
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'plain-co', 'owner_id' => $org->ID]);
     }
 }

--- a/tests/Feature/SamlClientWizardTest.php
+++ b/tests/Feature/SamlClientWizardTest.php
@@ -40,7 +40,7 @@ class SamlClientWizardTest extends TestCase
 
         $this->assertDatabaseHas('saml_clients', [
             'slug' => 'wizard-acme-health',
-            'organization_id' => 4242,
+            'owner_id' => 4242,
             'department_id' => 5000,
             'jit_enabled' => true,
             'enabled' => false,
@@ -104,6 +104,6 @@ class SamlClientWizardTest extends TestCase
             ->expectsOutputToContain('/saml/plain-co/acs')
             ->assertSuccessful();
 
-        $this->assertDatabaseHas('saml_clients', ['slug' => 'plain-co', 'organization_id' => 7]);
+        $this->assertDatabaseHas('saml_clients', ['slug' => 'plain-co', 'owner_id' => 7]);
     }
 }

--- a/tests/Feature/SamlLoginTest.php
+++ b/tests/Feature/SamlLoginTest.php
@@ -33,7 +33,7 @@ class SamlLoginTest extends TestCase
             'idp_entity_id' => 'https://idp.acme.test/metadata',
             'idp_sso_url' => 'https://idp.acme.test/sso',
             'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
-            'organization_id' => 933,
+            'owner_id' => 933,
             'department_id' => null,
             'jit_enabled' => true,
         ]);

--- a/tests/Feature/SamlRoutingRuleModelTest.php
+++ b/tests/Feature/SamlRoutingRuleModelTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SamlClient;
+use App\Models\SamlDepartmentRule;
+use App\Models\SamlOrgRule;
+use App\Saml\RoutingOperator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SamlRoutingRuleModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_operator_round_trips_as_enum(): void
+    {
+        $client = SamlClient::factory()->create();
+        $rule = SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id, 'operator' => RoutingOperator::NotContains,
+        ]);
+
+        $this->assertSame(RoutingOperator::NotContains, $rule->fresh()->operator);
+    }
+
+    public function test_relations_are_position_ordered(): void
+    {
+        $client = SamlClient::factory()->create();
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 2, 'organization_id' => 5]);
+        SamlOrgRule::factory()->create(['saml_client_id' => $client->id, 'position' => 1, 'organization_id' => 4]);
+
+        $this->assertSame([1, 2], $client->orgRules()->pluck('position')->all());
+        $this->assertSame([4, 5], $client->orgRules()->pluck('organization_id')->all());
+    }
+
+    public function test_catch_all_helper_requires_the_exact_triple(): void
+    {
+        $client = SamlClient::factory()->create();
+        $catchAll = SamlDepartmentRule::factory()->catchAll()->create(['saml_client_id' => $client->id]);
+        $wildcardOnValueOnly = SamlDepartmentRule::factory()->create([
+            'saml_client_id' => $client->id, 'position' => 2,
+            'attribute' => 'group', 'operator' => RoutingOperator::Wildcard, 'value' => '*',
+        ]);
+
+        $this->assertTrue($catchAll->isCatchAll());
+        $this->assertFalse($wildcardOnValueOnly->isCatchAll());
+    }
+}

--- a/tests/Feature/SsoGrantModelTest.php
+++ b/tests/Feature/SsoGrantModelTest.php
@@ -20,7 +20,8 @@ class SsoGrantModelTest extends TestCase
 
         $grant = SsoGrant::create([
             'user_id' => $user->ID,
-            'organization_id' => 933,
+            'owner_type' => 'organization',
+            'owner_id' => 933,
             'granted_by' => '1:Test Admin',
         ]);
 
@@ -30,7 +31,8 @@ class SsoGrantModelTest extends TestCase
 
         SsoGrant::create([
             'user_id' => $user->ID,
-            'organization_id' => 933,
+            'owner_type' => 'organization',
+            'owner_id' => 933,
             'granted_by' => '2:Other Admin',
         ]);
     }

--- a/tests/Feature/SsoGrantModelTest.php
+++ b/tests/Feature/SsoGrantModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SsoGrant;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SsoGrantModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_grant_links_user_and_enforces_uniqueness(): void
+    {
+        $user = User::factory()->create();
+
+        $grant = SsoGrant::create([
+            'user_id' => $user->ID,
+            'organization_id' => 933,
+            'granted_by' => '1:Test Admin',
+        ]);
+
+        $this->assertTrue($grant->user->is($user));
+
+        $this->expectException(QueryException::class);
+
+        SsoGrant::create([
+            'user_id' => $user->ID,
+            'organization_id' => 933,
+            'granted_by' => '2:Other Admin',
+        ]);
+    }
+}

--- a/tests/Feature/SystemOwnedLoginTest.php
+++ b/tests/Feature/SystemOwnedLoginTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Organization;
+use App\Models\SamlClient;
+use App\Models\System;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\SamlResponseFactory;
+use Tests\TestCase;
+
+class SystemOwnedLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // First-alphabetical RefreshDatabase caution does not apply (SystemOwnedLoginTest
+    // sorts after AdminApiSsoHandoffTest, which owns the seed pass).
+
+    private SamlClient $client;
+
+    private System $system;
+
+    private Organization $orgInSystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'saml.sp.cert_path' => base_path('tests/Fixtures/saml/sp.crt'),
+            'saml.sp.key_path' => base_path('tests/Fixtures/saml/sp.key'),
+            'saml.replay_store' => 'array',
+        ]);
+
+        $this->system = System::factory()->create();
+        $this->orgInSystem = Organization::factory()->create();
+        DB::table('SystemOrganizations')->insert([
+            'SystemID' => $this->system->ID,
+            'OrganizationID' => $this->orgInSystem->ID,
+        ]);
+
+        $this->client = SamlClient::factory()->forSystem($this->system->ID)->create([
+            'slug' => 'sys',
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+            'jit_enabled' => true,
+            'department_id' => null,
+        ]);
+    }
+
+    private function acs(array $responseOverrides = []): TestResponse
+    {
+        return $this->post('/saml/sys/acs', [
+            'SAMLResponse' => SamlResponseFactory::make(['destination' => url('/saml/sys/acs')] + $responseOverrides),
+        ]);
+    }
+
+    public function test_new_jit_user_on_system_client_is_rejected(): void
+    {
+        $response = $this->acs(); // sso.user@acme.test does not exist
+
+        $response->assertStatus(403);
+        $this->assertGuest();
+        $this->assertDatabaseMissing('Users', ['Login' => 'sso.user@acme.test']);
+    }
+
+    public function test_existing_user_gets_department_org_in_session(): void
+    {
+        $dept = Department::factory()->create(['OrganizationID' => $this->orgInSystem->ID]);
+        User::factory()->create(['Login' => 'done@acme.test', 'DepartmentID' => $dept->ID]);
+
+        $response = $this->acs(['nameId' => 'done@acme.test', 'attributes' => [
+            'email' => 'done@acme.test', 'firstName' => 'Done', 'lastName' => 'User',
+        ]]);
+
+        $response->assertRedirect('https://www.apexinnovations.com/MyCurriculum.php');
+        $response->assertSessionHas('Organization', $this->orgInSystem->ID);
+    }
+
+    public function test_org_owned_jit_fallback_is_unchanged(): void
+    {
+        // Sibling org-owned client on the same fixtures: JIT proceeds to finish flow.
+        $orgClient = SamlClient::factory()->create([
+            'slug' => 'acme2', 'jit_enabled' => true, 'department_id' => null,
+            'idp_entity_id' => 'https://idp.acme.test/metadata',
+            'idp_sso_url' => 'https://idp.acme.test/sso',
+            'idp_certificate' => file_get_contents(base_path('tests/Fixtures/saml/idp.crt')),
+        ]);
+
+        $this->post('/saml/acme2/acs', ['SAMLResponse' => SamlResponseFactory::make([
+            'destination' => url('/saml/acme2/acs'),
+        ])])->assertRedirect('/finishAccountCreation');
+
+        $this->assertDatabaseHas('Users', ['Login' => 'sso.user@acme.test', 'DepartmentID' => 0]);
+    }
+}

--- a/tests/Feature/SystemOwnedLoginTest.php
+++ b/tests/Feature/SystemOwnedLoginTest.php
@@ -82,6 +82,28 @@ class SystemOwnedLoginTest extends TestCase
         $response->assertSessionHas('Organization', $this->orgInSystem->ID);
     }
 
+    public function test_existing_dept_less_user_with_no_routing_rules_gets_null_organization(): void
+    {
+        // Baseline for the documented edge in SamlController::establishSession:
+        // an existing dept-less user (DepartmentID 0) on a system-owned client
+        // with no routing rules at all logs in successfully, but nothing ever
+        // resolved a placement, so the session Organization stays null until
+        // routing rules are configured.
+        User::factory()->create(['Login' => 'done@acme.test', 'DepartmentID' => 0]);
+
+        $response = $this->acs(['nameId' => 'done@acme.test', 'attributes' => [
+            'email' => 'done@acme.test', 'firstName' => 'Done', 'lastName' => 'User',
+        ]]);
+
+        $response->assertRedirect('/finishAccountCreation');
+        // assertSessionHas('Organization', null) can't pin this: Laravel's
+        // session has() treats a null-valued key as absent by design, so it
+        // would pass whether the key holds null or was never set. Assert the
+        // key was actually written (exists()) and its value is null.
+        $this->assertTrue(session()->exists('Organization'));
+        $this->assertNull(session()->get('Organization'));
+    }
+
     public function test_org_owned_jit_fallback_is_unchanged(): void
     {
         // Sibling org-owned client on the same fixtures: JIT proceeds to finish flow.

--- a/tests/Support/InteractsWithAdminApi.php
+++ b/tests/Support/InteractsWithAdminApi.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Support;
+
+trait InteractsWithAdminApi
+{
+    /**
+     * Configure the admin API token that adminApiHeaders() authenticates
+     * against. Call from setUp() after parent::setUp().
+     */
+    private function configureAdminApi(): void
+    {
+        config(['admin.api_token' => 'test-token']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function adminApiHeaders(?string $actingAdmin = '1:Test Admin'): array
+    {
+        $headers = ['Authorization' => 'Bearer test-token'];
+
+        if ($actingAdmin !== null) {
+            $headers['X-Acting-Admin'] = $actingAdmin;
+        }
+
+        return $headers;
+    }
+}

--- a/tests/Support/SeedsSystemHierarchy.php
+++ b/tests/Support/SeedsSystemHierarchy.php
@@ -4,7 +4,6 @@ namespace Tests\Support;
 
 use App\Models\Organization;
 use App\Models\System;
-use Illuminate\Support\Facades\DB;
 
 trait SeedsSystemHierarchy
 {
@@ -12,11 +11,8 @@ trait SeedsSystemHierarchy
     private function seedSystemWithTwoOrgs(): array
     {
         $system = System::factory()->create();
-        $orgA = Organization::factory()->create();
-        $orgB = Organization::factory()->create();
-
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
-        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+        $orgA = Organization::factory()->forSystem($system)->create();
+        $orgB = Organization::factory()->forSystem($system)->create();
 
         return [$system, $orgA, $orgB];
     }

--- a/tests/Support/SeedsSystemHierarchy.php
+++ b/tests/Support/SeedsSystemHierarchy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\Organization;
+use App\Models\System;
+use Illuminate\Support\Facades\DB;
+
+trait SeedsSystemHierarchy
+{
+    /** @return array{0: System, 1: Organization, 2: Organization} */
+    private function seedSystemWithTwoOrgs(): array
+    {
+        $system = System::factory()->create();
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgA->ID]);
+        DB::table('SystemOrganizations')->insert(['SystemID' => $system->ID, 'OrganizationID' => $orgB->ID]);
+
+        return [$system, $orgA, $orgB];
+    }
+}

--- a/tests/Unit/RoutingOperatorTest.php
+++ b/tests/Unit/RoutingOperatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Saml\RoutingOperator;
+use PHPUnit\Framework\TestCase;
+
+class RoutingOperatorTest extends TestCase
+{
+    public function test_equals_is_case_insensitive_and_matches_any_value(): void
+    {
+        $this->assertTrue(RoutingOperator::Equals->matchesAny(['Radiology', 'ICU'], 'icu'));
+        $this->assertFalse(RoutingOperator::Equals->matchesAny(['ICU-North'], 'icu'));
+    }
+
+    public function test_not_equals_requires_no_value_to_match(): void
+    {
+        $this->assertFalse(RoutingOperator::NotEquals->matchesAny(['ICU', 'ER'], 'icu'));
+        $this->assertTrue(RoutingOperator::NotEquals->matchesAny(['ER'], 'icu'));
+        // Vacuous: absent attribute (no values) satisfies every negated operator
+        $this->assertTrue(RoutingOperator::NotEquals->matchesAny([], 'icu'));
+    }
+
+    public function test_positive_operators_never_match_absent_attribute(): void
+    {
+        foreach ([RoutingOperator::Equals, RoutingOperator::Contains, RoutingOperator::StartsWith,
+            RoutingOperator::EndsWith, RoutingOperator::Wildcard, RoutingOperator::StrictWildcard] as $op) {
+            $this->assertFalse($op->matchesAny([], 'x'), $op->value);
+        }
+    }
+
+    public function test_contains_starts_ends_and_negations(): void
+    {
+        $this->assertTrue(RoutingOperator::Contains->matchesAny(['CN=ICU-Nurses,OU=Clinical'], 'icu-nurses'));
+        $this->assertFalse(RoutingOperator::NotContains->matchesAny(['CN=ICU-Nurses'], 'icu'));
+        $this->assertTrue(RoutingOperator::StartsWith->matchesAny(['DEPT-042'], 'dept-'));
+        $this->assertFalse(RoutingOperator::NotStartsWith->matchesAny(['DEPT-042'], 'DEPT'));
+        $this->assertTrue(RoutingOperator::EndsWith->matchesAny(['team-nursing'], 'NURSING'));
+        $this->assertTrue(RoutingOperator::NotEndsWith->matchesAny(['team-nursing'], 'admin'));
+    }
+
+    public function test_wildcard_is_anchored_and_case_insensitive(): void
+    {
+        $this->assertTrue(RoutingOperator::Wildcard->matchesAny(['CN=ICU-Nurses,OU=Clinical'], 'cn=icu-*'));
+        $this->assertFalse(RoutingOperator::Wildcard->matchesAny(['XCN=ICU-Nurses'], 'CN=*')); // anchored
+        $this->assertTrue(RoutingOperator::Wildcard->matchesAny(['anything at all'], '*'));
+        // Literal regex metacharacters must not leak through preg_quote
+        $this->assertTrue(RoutingOperator::Wildcard->matchesAny(['a.b+c'], 'a.b+c'));
+        $this->assertFalse(RoutingOperator::Wildcard->matchesAny(['aXb+c'], 'a.b+c'));
+    }
+
+    public function test_strict_wildcard_is_case_sensitive(): void
+    {
+        $this->assertTrue(RoutingOperator::StrictWildcard->matchesAny(['CN=ICU-01'], 'CN=ICU-*'));
+        $this->assertFalse(RoutingOperator::StrictWildcard->matchesAny(['cn=icu-01'], 'CN=ICU-*'));
+    }
+}


### PR DESCRIPTION
Supersedes #40 and #42 (closed, unmerged — their commits are all contained here). Per discussion with the Apex team, milestones 4 and 5 ship as **one reviewable unit** based directly on the deployed `development`, rather than four stacked PRs.

**Companion PR:** the admin portal's half lives in website_admin (single companion PR there, same consolidation). Deploy order at the end of this description.

## What this delivers

Everything between the deployed milestone 3 and the end of milestone 5, in four layers (56 commits, each layer building on the last):

### 1. Milestone 4 — SSO admin tools (+ UX follow-on)

- **Admin API** under `/api/admin` (token-auth via `ADMIN_API_TOKEN`, fail-closed; every mutation attributed via `X-Acting-Admin` and audit-logged): full SAML client CRUD over the same `SamlClientManager` the CLI uses, IdP metadata upload, enable/disable, org-scoped **SSO manager grants** (`sso_grants`), and read-only lookup endpoints powering the portal's searchable pickers.
- **Portal page** (website_admin): the SSO Clients admin page — Vue/Element UI island with org/department pickers, domain tags, metadata dialog, grants panel with user autocomplete. The browser never sees the API token (server-side bridge).
- **Migration isolation**: this app now tracks its migrations in `migrations_login` and the php-fpm image runs `migrate --force --isolated` at startup — no manual migration steps, ever; the shared `migrations` table is never touched.
- **Laravel Dusk** browser suite (selenium container) covering the real portal page.

### 2. Bonus — the admin portal itself behind SSO

- A SAML client flagged `admin_portal` asserts **Employee** identities: the ACS matches `Employees.Email` fail-closed (never auto-creates), mints a 60-second single-use handoff token (atomic claim — replay-safe), and redirects to the portal's `ssoLogon.php`, which redeems it server-side through the same API bridge and establishes the normal portal session + `AdminEvents` audit row. Failed redemptions are logged with a replay-vs-expired distinction.
- **The feature flag is the client's `enabled` state** — `saml:client disable apex-admin` or the portal toggle switches admin SSO off at runtime. Password login is untouched and coexists; SSO sessions skip the 90-day password-expiry redirect.
- Accepted, documented limitation: the handoff token isn't bound to the initiating browser (standard stateless-callback login-CSRF caveat, insider-only; RelayState binding is the future hardening).

### 3. Client ownership — organization or hospital system

- The Apex hierarchy is System → Organization → Department, and hospital systems run one IdP + one email domain across many orgs. A client is now owned at **either level**: `owner_type`/`owner_id` replaces `organization_id` on `saml_clients` *and* `sso_grants` (grants are owner-scoped: system-owned clients hold one system-wide manager list).
- Org-owned behavior is byte-for-byte what milestone 4 shipped (verified by the full pre-existing suite with only mechanical fixture updates). System-owned clients serve existing users (session org from the user's department); **new JIT users on them are rejected fail-closed** (`unrouted_user`) unless routing (layer 4) places them.
- CLI `--org` XOR `--system`, wizard owner step, API `owner {type, id, name}` payloads, systems lookup, portal owner-type picker (re-parenting is CLI-only and requires clearing rules/default department first — guarded).

### 4. Milestone 5 — attribute-based user routing

- **Cloudflare-page-rules-style placement**: per client, two ordered rule lists evaluated on every login — *organization rules* (system-owned clients: attribute/operator/value → org) and *department rules* (→ **department name**, resolved case-insensitively against the placed org's active departments, falling through when an org lacks that department). Name-targeting means a hospital system writes its department mappings **once** for all its orgs.
- **Ten operators** in a single backed enum (`RoutingOperator`): wildcard / strict-wildcard (case-insensitive vs sensitive `*`-patterns), equals, starts with, contains, ends with, and their negations. Negated operators against SAML's multi-valued attributes mean "no asserted value matches" (vacuously true when the attribute is absent). The catch-all is spelled in the grammar — the reserved `* wildcard *` triple, legal only as the last rule.
- **IdP-authoritative, never destructive**: a resolving department rule moves an existing user (logged); nothing ever demotes a user or wipes placement; org-owned clients keep their static default department as the no-match fallback; the session's legacy `Organization` key follows a placement only when it was actually applied.
- **Guardrails**: rule targets validated against the owner's scope at write time AND checked again at login (stale rules from a re-parent are skipped with a warning); re-parenting requires clearing rules first; catch-all-shadowed rules are rejected as unreachable.
- Managed everywhere: `GET/PUT /api/admin/saml-clients/{slug}/routing-rules` + `routable-organizations`, CLI `saml:client routing` (JSON `--set`/`--set-file`/`--clear`), and a portal rules editor (operator dropdowns, org picker, department-name autocomplete across the owner's scope, match-everyone toggle, reordering).

## Verification

- **261 backend tests** (734 assertions) on MySQL — operators unit-tested exhaustively, router/manager/API/CLI feature-tested, the full login matrix (JIT routed/unrouted/rescued/rejected, existing-user moves and never-demote, org/system × placement combinations) covered through the real ACS.
- **10 Dusk browser tests, green twice consecutively** — including a full round trip that creates a routing rule through the real portal panel, logs in through the real mock IdP, and asserts the user lands in the routed department; plus admin-portal SSO round trips and the SSO Clients page suite.
- Two mock IdP containers locally (`mock-idp`, `mock-idp-admin`) + seeded system/orgs/employees; `make db` wires everything.
- Every layer passed an independent final review with a fix pass (notable catches folded in: atomic handoff-token redemption, a half-pair owner-update validation hole, an org-owned default-department regression, login-time scope checks).

## Deploy notes

1. Migrations are additive and run automatically at container start (`migrations_login`). Deploy is inert: no admin client, no system-owned client, and no routing rules exist until an admin creates them.
2. `ADMIN_API_TOKEN` must be set (same value) in this app's and the portal's env before the portal page works; `LOGIN_SSO_CLIENT` + `ADMIN_PORTAL_URL` when admin SSO is enabled.
3. The companion website_admin PR should deploy with or after this one (its pages are thin clients of this API; they degrade gracefully but are useless without it).
4. Operational rule now documented in the runbook: **disable clients rather than deleting rows** — grants and routing rules have no DB-level cascade.
